### PR TITLE
readme: Use https for riscv clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installation
 A sample kernel with an initramfs is included in the "hacking_files"
 directory. You can easily test out riscv-qemu this way:
 
-    $ git clone git@github.com:ucb-bar/riscv-qemu.git
+    $ git clone https://github.com/ucb-bar/riscv-qemu
     $ cd riscv-qemu
     $ git submodule update --init pixman
     $ ./configure --target-list=riscv-softmmu
@@ -32,7 +32,7 @@ configuring the kernel/building a root fs will be available soon.
 
 ####Step 1:
 
-    $ git clone git@github.com:ucb-bar/riscv-qemu.git
+    $ git clone https://github.com/ucb-bar/riscv-qemu
     $ cd riscv-qemu
     $ git submodule update --init pixman
     $ ./configure --target-list=riscv-softmmu


### PR DESCRIPTION
Clone example used git@github which requires permissions to clone repository, preventing anonymous cloning. github recommends https as it is smart and will use appropriate access for your permissions. This will help people to get started. See https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-https-recommended
