### PR TITLE
riscv: enable -bios option

### DIFF
--- a/hw/riscv/riscv_board.c
+++ b/hw/riscv/riscv_board.c
@@ -152,6 +152,22 @@ static void riscv_board_init(QEMUMachineInitArgs *args)
     vmstate_register_ram_global(main_mem);
     memory_region_add_subregion(system_memory, 0x0, main_mem);
 
+    if (bios_name) {
+        int bios_size;
+        MemoryRegion *bios;
+        bios_size = get_image_size(bios_name);
+	if (bios_size > 0) {
+            bios = g_malloc(sizeof(*bios));
+            memory_region_init_ram(bios, NULL, "riscv.fw", bios_size);
+            vmstate_register_ram_global(bios);
+            memory_region_set_readonly(bios, true);
+            if (rom_add_file_fixed(bios_name, 0, -1) != 0) {
+                fprintf(stderr, "qemu: could not load RISC-V firmware '%s'\n", bios_name);
+                exit(1);
+            }
+	}
+    }
+
     if (kernel_filename) {
         /* Write a small bootloader to the flash location. */
         loaderparams.ram_size = ram_size;


### PR DESCRIPTION
With this option a coreboot image built for coreboot's
emulation/qemu-riscv target can be run successfully using

$ qemu-system-riscv -bios coreboot.rom

Signed-off-by: Patrick Georgi <pgeorgi@google.com>