### PR TITLE
Upstream cleanup

### DIFF
--- a/disas/riscv.c
+++ b/disas/riscv.c
@@ -11,7 +11,7 @@ int print_insn_riscv(bfd_vma pc, disassemble_info *info)
 
     #ifdef USE_SPIKE_DASM
     int buflen = 100;
-    char * runbuf = g_malloc(buflen); // TODO len
+    char *runbuf = g_malloc(buflen); /* TODO len */
     #endif
 
     info->read_memory_func(pc, buf, n, info);
@@ -21,16 +21,17 @@ int print_insn_riscv(bfd_vma pc, disassemble_info *info)
     for (j = 0; j < n; j += 4) {
         info->fprintf_func(info->stream, "\n%s: 0x", prefix);
 
-        // little-endian
+        /* little-endian */
         for (i = 3; i >= 0; --i) {
-            info->fprintf_func(info->stream, "%02x", buf[j+i]);
+            info->fprintf_func(info->stream, "%02x", buf[j + i]);
         }
 
-        // use spike-dasm
+        /* use spike-dasm */
         #ifdef USE_SPIKE_DASM
         info->fprintf_func(info->stream, "\n");
-        snprintf(runbuf, buflen, "echo 'DASM(%02x%02x%02x%02x)\n' | spike-dasm 1>&2", 
-                buf[j+3], buf[j+2], buf[j+1], buf[j+0]);
+        snprintf(runbuf, buflen, "echo 'DASM(%02x%02x%02x%02x)\n' \
+                 | spike-dasm 1>&2", buf[j + 3], buf[j + 2], buf[j + 1],
+                 buf[j + 0]);
         int res = system(runbuf);
         if (res) {
             printf("spike-dasm error\n");

--- a/fpu/softfloat-specialize.h
+++ b/fpu/softfloat-specialize.h
@@ -114,7 +114,8 @@ float32 float32_default_nan(float_status *status)
 #if defined(TARGET_SPARC)
     return const_float32(0x7FFFFFFF);
 #elif defined(TARGET_PPC) || defined(TARGET_ARM) || defined(TARGET_ALPHA) || \
-      defined(TARGET_XTENSA) || defined(TARGET_S390X) || defined(TARGET_TRICORE) || defined(TARGET_RISCV)
+      defined(TARGET_XTENSA) || defined(TARGET_S390X) || \
+      defined(TARGET_TRICORE) || defined(TARGET_RISCV)
     return const_float32(0x7FC00000);
 #else
     if (status->snan_bit_is_one) {

--- a/hw/riscv/htif/elf_symb.c
+++ b/hw/riscv/htif/elf_symb.c
@@ -1,8 +1,9 @@
 /*
  * elf.c - A simple package for manipulating symbol tables in elf binaries.
  *
- * Taken from 
- * https://www.cs.cmu.edu/afs/cs.cmu.edu/academic/class/15213-f03/www/ftrace/elf.c
+ * Taken from
+ * https://www.cs.cmu.edu/afs/cs.cmu.edu/academic/class/15213-f03/www/
+ * ftrace/elf.c
  *
  */
 #include <stdio.h>
@@ -14,61 +15,59 @@
 #include <sys/mman.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <glib.h>
 
 #include "elf_symb.h"
 
-/* 
+/*
  * elf_open - Map a binary into the address space and extract the
  * locations of the static and dynamic symbol tables and their string
  * tables. Return this information in a Elf object file handle that will
  * be passed to all of the other elf functions.
  */
-Elf_obj *elf_open(const char *filename) 
+Elf_obj *elf_open(const char *filename)
 {
     int i, fd;
     struct stat sbuf;
     Elf_obj *ep;
     Elf64_Shdr *shdr;
 
-    if ((ep = (Elf_obj *) malloc(sizeof(Elf_obj))) == NULL) {
-    fprintf(stderr, "Malloc failed: %s\n", strerror(errno));
-    exit(1);
-    }
+    ep = g_new(Elf_obj, 1);
 
     /* Do some consistency checks on the binary */
     fd = open(filename, O_RDONLY);
     if (fd == -1) {
-    fprintf(stderr, "Can't open \"%s\": %s\n", filename, strerror(errno));
-    exit(1);
+        fprintf(stderr, "Can't open \"%s\": %s\n", filename, strerror(errno));
+        exit(1);
     }
     if (fstat(fd, &sbuf) == -1) {
-    fprintf(stderr, "Can't stat \"%s\": %s\n", filename, strerror(errno));
-    exit(1);
+        fprintf(stderr, "Can't stat \"%s\": %s\n", filename, strerror(errno));
+        exit(1);
     }
     if (sbuf.st_size < sizeof(Elf64_Ehdr)) {
-    fprintf(stderr, "\"%s\" is not an ELF binary object\n", filename);
-    exit(1);
+        fprintf(stderr, "\"%s\" is not an ELF binary object\n", filename);
+        exit(1);
     }
 
     /* It looks OK, so map the Elf binary into our address space */
     ep->mlen = sbuf.st_size;
     ep->maddr = mmap(NULL, ep->mlen, PROT_READ, MAP_SHARED, fd, 0);
     if (ep->maddr == (void *)-1) {
-    fprintf(stderr, "Can't mmap \"%s\": %s\n", filename, strerror(errno));
-    exit(1);
+        fprintf(stderr, "Can't mmap \"%s\": %s\n", filename, strerror(errno));
+        exit(1);
     }
     close(fd);
 
     /* The Elf binary begins with the Elf header */
     ep->ehdr = ep->maddr;
 
-    /* Make sure that this is an Elf binary */ 
-/*    if (strncmp(ep->ehdr->e_ident, ELFMAG, SELFMAG)) {
+    /* Make sure that this is an Elf binary */
+    /*    if (strncmp(ep->ehdr->e_ident, ELFMAG, SELFMAG)) {
     fprintf(stderr, "\"%s\" is not an ELF binary object\n", filename);
     exit(1);
     }*/
 
-    /* 
+    /*
      * Find the static and dynamic symbol tables and their string
      * tables in the the mapped binary. The sh_link field in symbol
      * table section headers gives the section index of the string
@@ -76,72 +75,71 @@ Elf_obj *elf_open(const char *filename)
      */
     shdr = (Elf64_Shdr *)(ep->maddr + ep->ehdr->e_shoff);
     for (i = 0; i < ep->ehdr->e_shnum; i++) {
-    if (shdr[i].sh_type == SHT_SYMTAB) {   /* Static symbol table */
-        ep->symtab = (Elf64_Sym *)(ep->maddr + shdr[i].sh_offset);
-        ep->symtab_end = (Elf64_Sym *)((char *)ep->symtab + shdr[i].sh_size);
-        ep->strtab = (char *)(ep->maddr + shdr[shdr[i].sh_link].sh_offset);
-    }
-    if (shdr[i].sh_type == SHT_DYNSYM) {   /* Dynamic symbol table */
-        ep->dsymtab = (Elf64_Sym *)(ep->maddr + shdr[i].sh_offset);
-        ep->dsymtab_end = (Elf64_Sym *)((char *)ep->dsymtab + shdr[i].sh_size);
-        ep->dstrtab = (char *)(ep->maddr + shdr[shdr[i].sh_link].sh_offset);
-    }
+        if (shdr[i].sh_type == SHT_SYMTAB) {   /* Static symbol table */
+            ep->symtab = (Elf64_Sym *)(ep->maddr + shdr[i].sh_offset);
+            ep->symtab_end = (Elf64_Sym *)((char *)ep->symtab +
+                             shdr[i].sh_size);
+            ep->strtab = (char *)(ep->maddr + shdr[shdr[i].sh_link].sh_offset);
+        }
+        if (shdr[i].sh_type == SHT_DYNSYM) {   /* Dynamic symbol table */
+            ep->dsymtab = (Elf64_Sym *)(ep->maddr + shdr[i].sh_offset);
+            ep->dsymtab_end = (Elf64_Sym *)((char *)ep->dsymtab +
+                              shdr[i].sh_size);
+            ep->dstrtab = (char *)(ep->maddr + shdr[shdr[i].sh_link].sh_offset);
+        }
     }
     return ep;
 }
 
-/* 
+/*
  * elf_open - Map a binary into the address space and extract the
  * locations of the static and dynamic symbol tables and their string
  * tables. Return this information in a Elf object file handle that will
  * be passed to all of the other elf functions.
  */
-Elf_obj32 *elf_open32(const char *filename) 
+Elf_obj32 *elf_open32(const char *filename)
 {
     int i, fd;
     struct stat sbuf;
     Elf_obj32 *ep;
     Elf32_Shdr *shdr;
 
-    if ((ep = (Elf_obj32 *) malloc(sizeof(Elf_obj32))) == NULL) {
-    fprintf(stderr, "Malloc failed: %s\n", strerror(errno));
-    exit(1);
-    }
+    ep = g_new(Elf_obj32, 1);
 
     /* Do some consistency checks on the binary */
     fd = open(filename, O_RDONLY);
     if (fd == -1) {
-    fprintf(stderr, "Can't open \"%s\": %s\n", filename, strerror(errno));
-    exit(1);
+        fprintf(stderr, "Can't open \"%s\": %s\n", filename, strerror(errno));
+        exit(1);
     }
     if (fstat(fd, &sbuf) == -1) {
-    fprintf(stderr, "Can't stat \"%s\": %s\n", filename, strerror(errno));
-    exit(1);
+        fprintf(stderr, "Can't stat \"%s\": %s\n", filename, strerror(errno));
+        exit(1);
     }
     if (sbuf.st_size < sizeof(Elf32_Ehdr)) {
-    fprintf(stderr, "\"%s\" is not an ELF binary object\n", filename);
-    exit(1);
+        fprintf(stderr, "\"%s\" is not an ELF binary object\n", filename);
+        exit(1);
     }
 
     /* It looks OK, so map the Elf binary into our address space */
     ep->mlen = sbuf.st_size;
     ep->maddr = mmap(NULL, ep->mlen, PROT_READ, MAP_SHARED, fd, 0);
     if (ep->maddr == (void *)-1) {
-    fprintf(stderr, "Can't mmap \"%s\": %s\n", filename, strerror(errno));
-    exit(1);
+        fprintf(stderr, "Can't mmap \"%s\": %s\n", filename, strerror(errno));
+        exit(1);
     }
     close(fd);
 
     /* The Elf binary begins with the Elf header */
     ep->ehdr = ep->maddr;
 
-    /* Make sure that this is an Elf binary */ 
+    /* Make sure that this is an Elf binary */
 /*    if (strncmp(ep->ehdr->e_ident, ELFMAG, SELFMAG)) {
     fprintf(stderr, "\"%s\" is not an ELF binary object\n", filename);
     exit(1);
     }*/
 
-    /* 
+    /*
      * Find the static and dynamic symbol tables and their string
      * tables in the the mapped binary. The sh_link field in symbol
      * table section headers gives the section index of the string
@@ -149,28 +147,30 @@ Elf_obj32 *elf_open32(const char *filename)
      */
     shdr = (Elf32_Shdr *)(ep->maddr + ep->ehdr->e_shoff);
     for (i = 0; i < ep->ehdr->e_shnum; i++) {
-    if (shdr[i].sh_type == SHT_SYMTAB) {   /* Static symbol table */
-        ep->symtab = (Elf32_Sym *)(ep->maddr + shdr[i].sh_offset);
-        ep->symtab_end = (Elf32_Sym *)((char *)ep->symtab + shdr[i].sh_size);
-        ep->strtab = (char *)(ep->maddr + shdr[shdr[i].sh_link].sh_offset);
-    }
-    if (shdr[i].sh_type == SHT_DYNSYM) {   /* Dynamic symbol table */
-        ep->dsymtab = (Elf32_Sym *)(ep->maddr + shdr[i].sh_offset);
-        ep->dsymtab_end = (Elf32_Sym *)((char *)ep->dsymtab + shdr[i].sh_size);
-        ep->dstrtab = (char *)(ep->maddr + shdr[shdr[i].sh_link].sh_offset);
-    }
+        if (shdr[i].sh_type == SHT_SYMTAB) {   /* Static symbol table */
+            ep->symtab = (Elf32_Sym *)(ep->maddr + shdr[i].sh_offset);
+            ep->symtab_end = (Elf32_Sym *)((char *)ep->symtab +
+                             shdr[i].sh_size);
+            ep->strtab = (char *)(ep->maddr + shdr[shdr[i].sh_link].sh_offset);
+        }
+        if (shdr[i].sh_type == SHT_DYNSYM) {   /* Dynamic symbol table */
+            ep->dsymtab = (Elf32_Sym *)(ep->maddr + shdr[i].sh_offset);
+            ep->dsymtab_end = (Elf32_Sym *)((char *)ep->dsymtab +
+                              shdr[i].sh_size);
+            ep->dstrtab = (char *)(ep->maddr + shdr[shdr[i].sh_link].sh_offset);
+        }
     }
     return ep;
 }
 
-/* 
+/*
  * elf_close - Free up the resources of an  elf object
  */
-void elf_close(Elf_obj *ep) 
+void elf_close(Elf_obj *ep)
 {
     if (munmap(ep->maddr, ep->mlen) < 0) {
-    perror("munmap");
-    exit(1);
+        perror("munmap");
+        exit(1);
     }
     free(ep);
 }
@@ -194,7 +194,7 @@ char *elf_symname32(Elf_obj32 *ep, Elf32_Sym *sym)
 
 /*
  * elf_dsymname - Return ASCII name of a dynamic symbol
- */ 
+ */
 char *elf_dsymname(Elf_obj *ep, Elf64_Sym *sym)
 {
     return &ep->dstrtab[sym->st_name];
@@ -224,10 +224,11 @@ Elf32_Sym *elf_firstsym32(Elf_obj32 *ep)
 Elf64_Sym *elf_nextsym(Elf_obj *ep, Elf64_Sym *sym)
 {
     sym++;
-    if (sym < ep->symtab_end)
-    return sym;
-    else
-    return NULL;
+    if (sym < ep->symtab_end) {
+        return sym;
+    } else {
+        return NULL;
+    }
 }
 
 /*
@@ -237,10 +238,11 @@ Elf64_Sym *elf_nextsym(Elf_obj *ep, Elf64_Sym *sym)
 Elf32_Sym *elf_nextsym32(Elf_obj32 *ep, Elf32_Sym *sym)
 {
     sym++;
-    if (sym < ep->symtab_end)
-    return sym;
-    else
-    return NULL;
+    if (sym < ep->symtab_end) {
+        return sym;
+    } else {
+        return NULL;
+    }
 }
 
 
@@ -255,29 +257,30 @@ Elf64_Sym *elf_firstdsym(Elf_obj *ep)
 /*
  * elf_nextdsym - Return ptr to next symbol in dynamic symbol table,
  * of NULL if no more symbols.
- */ 
+ */
 Elf64_Sym *elf_nextdsym(Elf_obj *ep, Elf64_Sym *sym)
 {
     sym++;
-    if (sym < ep->dsymtab_end)
-    return sym;
-    else
-    return NULL;
+    if (sym < ep->dsymtab_end) {
+        return sym;
+    } else {
+        return NULL;
+    }
 }
 
 /*
  * elf_isfunc - Return true if symbol is a static function
  */
-int elf_isfunc(Elf_obj *ep, Elf64_Sym *sym) 
+int elf_isfunc(Elf_obj *ep, Elf64_Sym *sym)
 {
     return ((ELF32_ST_TYPE(sym->st_info) == STT_FUNC) &&
         (sym->st_shndx != SHT_NULL));
 }
 
 /*
- * elf_isdfunc - Return true if symbol is a dynamic function 
+ * elf_isdfunc - Return true if symbol is a dynamic function
  */
-int elf_isdfunc(Elf_obj *ep, Elf64_Sym *sym) 
+int elf_isdfunc(Elf_obj *ep, Elf64_Sym *sym)
 {
     return ((ELF32_ST_TYPE(sym->st_info) == STT_FUNC));
 }

--- a/hw/riscv/htif/elf_symb.h
+++ b/hw/riscv/htif/elf_symb.h
@@ -1,8 +1,9 @@
-/* 
+/*
  * elf.h - A package for manipulating Elf binaries
  *
  * Taken from:
- * https://www.cs.cmu.edu/afs/cs.cmu.edu/academic/class/15213-f03/www/ftrace/elf.h
+ * https://www.cs.cmu.edu/afs/cs.cmu.edu/academic/class/15213-f03/www/ftrace/
+ * elf.h
  *
  */
 
@@ -12,9 +13,9 @@
 #include <stdint.h>
 #include <elf.h>
 
-/* 
+/*
  * This is a handle that is created by elf_open and then used by every
- * other function in the elf package 
+ * other function in the elf package
 */
 typedef struct {
     void *maddr;            /* Start of mapped Elf binary segment in memory */
@@ -25,7 +26,7 @@ typedef struct {
     char *strtab;           /* Address of string table */
     Elf64_Sym *dsymtab;     /* Start of dynamic symbol table */
     Elf64_Sym *dsymtab_end; /* End of dynamic symbol table (dsymtab + size) */
-    char *dstrtab;          /* Address of dynamic string table */ 
+    char *dstrtab;          /* Address of dynamic string table */
 } Elf_obj;
 
 typedef struct {
@@ -37,18 +38,18 @@ typedef struct {
     char *strtab;           /* Address of string table */
     Elf32_Sym *dsymtab;     /* Start of dynamic symbol table */
     Elf32_Sym *dsymtab_end; /* End of dynamic symbol table (dsymtab + size) */
-    char *dstrtab;          /* Address of dynamic string table */ 
+    char *dstrtab;          /* Address of dynamic string table */
 } Elf_obj32;
 
-/* 
+/*
  * Create and destroy Elf object handles
  */
 Elf_obj *elf_open(const char *filename);
 Elf_obj32 *elf_open32(const char *filename);
 
-void elf_close(Elf_obj *ep); 
+void elf_close(Elf_obj *ep);
 
-/* 
+/*
  * Functions for manipulating static symbols
  */
 
@@ -67,7 +68,7 @@ char *elf_symname32(Elf_obj32 *ep, Elf32_Sym *sym);
 /* True if symbol is a function */
 int elf_isfunc(Elf_obj *ep, Elf64_Sym *sym);
 
-/* 
+/*
  * Corresponding functions for manipulating dynamic symbols
  */
 Elf64_Sym *elf_firstdsym(Elf_obj *ep);

--- a/hw/riscv/riscv_board.c
+++ b/hw/riscv/riscv_board.c
@@ -57,7 +57,7 @@
 #include "hw/i2c/smbus.h"
 #include "block/block.h"
 #include "hw/block/flash.h"
-#include "block/block_int.h" // move later
+#include "block/block_int.h" /* move later */
 #include "hw/riscv/riscv.h"
 #include "hw/riscv/cpudevs.h"
 #include "hw/pci/pci.h"
@@ -100,7 +100,7 @@ uint64_t identity_translate(void *opaque, uint64_t addr)
     return addr;
 }
 
-static int64_t load_kernel (void)
+static int64_t load_kernel(void)
 {
     int64_t kernel_entry, kernel_high;
     int big_endian;
@@ -138,7 +138,7 @@ static void riscv_board_init(MachineState *args)
     object_property_set_bool(OBJECT(dev), true, "realized", NULL);
 
     /* Make sure the first 3 serial ports are associated with a device. */
-    for(i = 0; i < 3; i++) {
+    for (i = 0; i < 3; i++) {
         if (!serial_hds[i]) {
             char label[32];
             snprintf(label, sizeof(label), "serial%d", i);
@@ -168,8 +168,9 @@ static void riscv_board_init(MachineState *args)
     env = &cpu->env;
 
     /* register system main memory (actual RAM) */
-    memory_region_init_ram(main_mem, NULL, "riscv_board.ram", 2147483648L + ram_size, &error_fatal);
-    // for CSR_MIOBASE
+    memory_region_init_ram(main_mem, NULL, "riscv_board.ram", 2147483648L +
+                           ram_size, &error_fatal);
+    /* for CSR_MIOBASE */
     env->memsize = ram_size;
     vmstate_register_ram_global(main_mem);
     memory_region_add_subregion(system_memory, 0x0, main_mem);
@@ -183,16 +184,16 @@ static void riscv_board_init(MachineState *args)
     }
 
     uint32_t reset_vec[8] = {
-        0x297 + 0x80000000 - 0x1000, // reset vector
-        0x00028067,                  // jump to DRAM_BASE
-        0x00000000,                  // reserved
-        0x0,                         // config string pointer
-        0, 0, 0, 0                   // trap vector
+        0x297 + 0x80000000 - 0x1000, /* reset vector */
+        0x00028067,                  /* jump to DRAM_BASE */
+        0x00000000,                  /* reserved */
+        0x0,                         /* config string pointer */
+        0, 0, 0, 0                   /* trap vector */
     };
-    reset_vec[3] = 0x1000 + sizeof(reset_vec); // config string pointer
+    reset_vec[3] = 0x1000 + sizeof(reset_vec); /* config string pointer */
 
-    // part one of config string - before memory size specified
-    const char * config_string1 = "platform {\n"
+    /* part one of config string - before memory size specified */
+    const char *config_string1 = "platform {\n"
         "  vendor ucb;\n"
         "  arch spike;\n"
         "};\n"
@@ -203,10 +204,10 @@ static void riscv_board_init(MachineState *args)
         "  0 {\n"
         "    addr 0x" "80000000" ";\n"
         "    size 0x";
-   
-   
-    // part two of config string - after memory size specified 
-    const char * config_string2 =  ";\n"
+
+
+    /* part two of config string - after memory size specified */
+    const char *config_string2 =  ";\n"
         "  };\n"
         "};\n"
         "core {\n"
@@ -219,38 +220,42 @@ static void riscv_board_init(MachineState *args)
           "  };\n"
           "};\n";
 
-    // build config string with supplied memory size
+    /* build config string with supplied memory size */
     uint64_t rsz = ram_size;
-    char * ramsize_as_hex_str = malloc(17);
+    char *ramsize_as_hex_str = malloc(17);
     sprintf(ramsize_as_hex_str, "%016lx", rsz);
-    char * config_string = malloc(strlen(config_string1) + strlen(ramsize_as_hex_str) + strlen(config_string2) + 1);
+    char *config_string = malloc(strlen(config_string1) +
+                                  strlen(ramsize_as_hex_str) +
+                                  strlen(config_string2) + 1);
     config_string[0] = 0;
     strcat(config_string, config_string1);
     strcat(config_string, ramsize_as_hex_str);
     strcat(config_string, config_string2);
 
-    // copy in the reset vec and configstring
+    /* copy in the reset vec and configstring */
     int q;
-    for (q = 0; q < sizeof(reset_vec)/sizeof(reset_vec[0]); q++) {
-        stl_p(memory_region_get_ram_ptr(main_mem)+0x1000+q*4, reset_vec[q]);
+    for (q = 0; q < sizeof(reset_vec) / sizeof(reset_vec[0]); q++) {
+        stl_p(memory_region_get_ram_ptr(main_mem) + 0x1000 + q * 4,
+              reset_vec[q]);
     }
 
     int confstrlen = strlen(config_string);
     for (q = 0; q < confstrlen; q++) {
-        stb_p(memory_region_get_ram_ptr(main_mem)+reset_vec[3]+q, config_string[q]);
+        stb_p(memory_region_get_ram_ptr(main_mem) + reset_vec[3] + q,
+              config_string[q]);
     }
 
-    // add memory mapped htif registers at location specified in the symbol
-    // table of the elf being loaded (thus kernel_filename is passed to the 
-    // init rather than an address)
+    /* add memory mapped htif registers at location specified in the symbol
+       table of the elf being loaded (thus kernel_filename is passed to the
+       init rather than an address) */
 
     htif_mm_init(system_memory, kernel_filename, env->irq[4], main_mem,
             kernel_cmdline, env, serial_hds[0]);
 
-    // timer device at 0x40000000, as specified in the config string above
+    /* timer device at 0x40000000, as specified in the config string above */
     timer_mm_init(system_memory, 0x40000000, env);
 
-    // Softint "devices" for cleaner handling of CPU-triggered interrupts
+    /* Softint "devices" for cleaner handling of CPU-triggered interrupts */
     softint_mm_init(system_memory, 0xFFFFFFFFF0000020L, env->irq[1], main_mem,
             env, "SSIP");
 
@@ -260,7 +265,7 @@ static void riscv_board_init(MachineState *args)
     softint_mm_init(system_memory, 0xFFFFFFFFF0000060L, env->irq[3], main_mem,
             env, "MSIP");
 
-    // TODO: VIRTIO
+    /* TODO: VIRTIO */
 }
 
 static int riscv_board_sysbus_device_init(SysBusDevice *sysbusdev)

--- a/hw/riscv/riscv_int.c
+++ b/hw/riscv/riscv_int.c
@@ -36,19 +36,20 @@
  */
 static void cpu_riscv_irq_request(void *opaque, int irq, int level)
 {
-    // TODO fixup post 1.9
-    // This "irq" number is not a real irq number, just some set of numbers
-    // we choose. These are not the same irq numbers visible to the processor.
+    /* TODO fixup post 1.9
+       This "irq" number is not a real irq number, just some set of numbers
+       we choose. These are not the same irq numbers visible to the
+       processor. */
 
     RISCVCPU *cpu = opaque;
     CPURISCVState *env = &cpu->env;
     CPUState *cs = CPU(cpu);
 
-    // current irqs:
-    // 7: Machine Timer. MIP_MTIP should have already been set
-    // 4: Host Interrupt. mfromhost should have a nonzero value
-    // 3, 2, 1: Interrupts triggered by the CPU. At least one of
-    //    MIP_STIP, MIP_SSIP, MIP_MSIP should already be set
+    /* current irqs:
+       7: Machine Timer. MIP_MTIP should have already been set
+       4: Host Interrupt. mfromhost should have a nonzero value
+       3, 2, 1: Interrupts triggered by the CPU. At least one of
+       MIP_STIP, MIP_SSIP, MIP_MSIP should already be set */
     if (unlikely(irq != 7 && !(irq < 5 && irq > 0))) {
         fprintf(stderr, "Unused IRQ was raised.\n");
         exit(1);
@@ -58,7 +59,7 @@ static void cpu_riscv_irq_request(void *opaque, int irq, int level)
         cpu_interrupt(cs, CPU_INTERRUPT_HARD);
     } else {
         if (!env->csr[CSR_MIP] && !env->mfromhost) {
-            // no interrupts pending, no host interrupt for HTIF, reset
+            /* no interrupts pending, no host interrupt for HTIF, reset */
             cpu_reset_interrupt(cs, CPU_INTERRUPT_HARD);
         }
     }

--- a/hw/riscv/riscv_softint.c
+++ b/hw/riscv/riscv_softint.c
@@ -63,14 +63,14 @@ const VMStateDescription vmstate_softint = {
     },
 };
 
-// CPU wants to read an Softint register. Should not happen.
+/* CPU wants to read an Softint register. Should not happen. */
 static uint64_t softint_mm_read(void *opaque, hwaddr addr, unsigned size)
 {
     fprintf(stderr, "Unimplemented read softint\n");
     exit(1);
 }
 
-// CPU wrote to an Softint register
+/* CPU wrote to an Softint register */
 static void softint_mm_write(void *opaque, hwaddr addr,
                             uint64_t value, unsigned size)
 {
@@ -83,7 +83,8 @@ static void softint_mm_write(void *opaque, hwaddr addr,
             qemu_irq_lower(softintstate->irq);
         }
     } else {
-        fprintf(stderr, "Invalid softint register address %016lx\n", (uint64_t)addr);
+        fprintf(stderr, "Invalid softint register address %016lx\n",
+                (uint64_t)addr);
         exit(1);
     }
 }
@@ -96,10 +97,11 @@ static const MemoryRegionOps softint_mm_ops[3] = {
     },
 };
 
-SoftintState *softint_mm_init(MemoryRegion *address_space, hwaddr base, qemu_irq irq,
-                        MemoryRegion *main_mem, CPURISCVState *env, const char * name)
+SoftintState *softint_mm_init(MemoryRegion *address_space, hwaddr base,
+                              qemu_irq irq, MemoryRegion *main_mem,
+                              CPURISCVState *env, const char * name)
 {
-    // TODO: cleanup the constant buffer sizes
+    /* TODO: cleanup the constant buffer sizes */
     SoftintState *softintstate;
 
     softintstate = g_malloc0(sizeof(SoftintState));
@@ -107,7 +109,7 @@ SoftintState *softint_mm_init(MemoryRegion *address_space, hwaddr base, qemu_irq
     softintstate->address_space = address_space;
     softintstate->env = env;
 
-    char * badbuf = g_malloc0(sizeof(char)*100);
+    char *badbuf = g_malloc0(sizeof(char) * 100);
     sprintf(badbuf, "%s%s", "softint", name);
     softintstate->name = badbuf;
 

--- a/include/elf.h
+++ b/include/elf.h
@@ -112,7 +112,7 @@ typedef int64_t  Elf64_Sxword;
 
 #define EM_UNICORE32    110     /* UniCore32 */
 
-#define EM_RISCV	243	/* RISC-V */
+#define EM_RISCV 243 /* RISC-V */
 
 /*
  * This is an interim value that we will use until the committee comes

--- a/include/hw/riscv/htif/frontend.h
+++ b/include/hw/riscv/htif/frontend.h
@@ -14,18 +14,21 @@
 #define RV_FSYSCALL_sys_exit  93
 #define RV_FSYSCALL_sys_getmainvars 2011
 
-uint64_t sys_openat(HTIFState *htifstate, uint64_t dirfd, uint64_t pname, uint64_t len, uint64_t flags, uint64_t mode);
+uint64_t sys_openat(HTIFState *htifstate, uint64_t dirfd, uint64_t pname,
+                    uint64_t len, uint64_t flags, uint64_t mode);
 
 uint64_t sys_close(HTIFState *htifstate, uint64_t fd);
 
-uint64_t sys_write(HTIFState *htifstate, uint64_t fd, uint64_t pbuf, uint64_t len);
+uint64_t sys_write(HTIFState *htifstate, uint64_t fd, uint64_t pbuf,
+                   uint64_t len);
 
-uint64_t sys_pread(HTIFState *htifstate, uint64_t fd, uint64_t pbuf, uint64_t len, uint64_t off);
+uint64_t sys_pread(HTIFState *htifstate, uint64_t fd, uint64_t pbuf,
+                   uint64_t len, uint64_t off);
 
 uint64_t sys_exit(HTIFState *htifstate, uint64_t code);
 
-int handle_frontend_syscall(HTIFState * htifstate, uint64_t payload);
+int handle_frontend_syscall(HTIFState *htifstate, uint64_t payload);
 
-uint64_t sys_getmainvars(HTIFState * htifstate, uint64_t pbuf, uint64_t limit);
+uint64_t sys_getmainvars(HTIFState *htifstate, uint64_t pbuf, uint64_t limit);
 
 #endif

--- a/include/hw/riscv/htif/htif.h
+++ b/include/hw/riscv/htif/htif.h
@@ -38,11 +38,11 @@ struct HTIFState {
     hwaddr fromhost_offset;
     uint64_t tohost_size;
     uint64_t fromhost_size;
-    qemu_irq irq; // host interrupt line
+    qemu_irq irq; /* host interrupt line */
     MemoryRegion io;
-    MemoryRegion* address_space;
-    MemoryRegion* main_mem;
-    void* main_mem_ram_ptr;
+    MemoryRegion *address_space;
+    MemoryRegion *main_mem;
+    void *main_mem_ram_ptr;
 
     CPURISCVState *env;
     CharDriverState *chr;
@@ -50,17 +50,17 @@ struct HTIFState {
 
 
     int block_dev_present;
-    // TODO: eventually move the following to a separate HTIF block device driver
+    /* TODO: eventually move the following to a separate HTIF block device
+             driver */
     const char *block_fname;
     int block_fd;
     char *real_name;
-    char *kernel_cmdline; // for sys_getmainvars
+    char *kernel_cmdline; /* for sys_getmainvars */
 };
 
 typedef struct request_t request_t;
 
-struct request_t
-{ 
+struct request_t {
     uint64_t addr;
     uint64_t offset;
     uint64_t size;
@@ -71,9 +71,9 @@ extern const VMStateDescription vmstate_htif;
 extern const MemoryRegionOps htif_io_ops;
 
 /* legacy pre qom */
-HTIFState *htif_mm_init(MemoryRegion *address_space, const char* kernel_filename, 
-                    qemu_irq irq, MemoryRegion *main_mem,
-                    const char *kernel_cmdline, CPURISCVState *env,
-                    CharDriverState *chr);
+HTIFState *htif_mm_init(MemoryRegion *address_space,
+                        const char *kernel_filename, qemu_irq irq,
+                        MemoryRegion *main_mem, const char *kernel_cmdline,
+                        CPURISCVState *env, CharDriverState *chr);
 
 #endif

--- a/include/hw/riscv/riscv_rtc.h
+++ b/include/hw/riscv/riscv_rtc.h
@@ -19,7 +19,7 @@ extern const VMStateDescription vmstate_timer_rv;
 extern const MemoryRegionOps timer_io_ops;
 
 /* legacy pre qom */
-TIMERState *timer_mm_init(MemoryRegion *address_space, hwaddr base, 
-                    CPURISCVState *env);
+TIMERState *timer_mm_init(MemoryRegion *address_space, hwaddr base,
+                          CPURISCVState *env);
 
 #endif

--- a/include/hw/riscv/riscv_softint.h
+++ b/include/hw/riscv/riscv_softint.h
@@ -31,21 +31,21 @@
 typedef struct SoftintState SoftintState;
 
 struct SoftintState {
-    qemu_irq irq; // host interrupt line
+    qemu_irq irq; /* host interrupt line */
     MemoryRegion io;
-    MemoryRegion* address_space;
+    MemoryRegion *address_space;
 
     CPURISCVState *env;
     CharDriverState *chr;
-    char * name;
+    char *name;
 };
 
 extern const VMStateDescription vmstate_softint;
 extern const MemoryRegionOps softint_io_ops;
 
 /* legacy pre qom */
-SoftintState *softint_mm_init(MemoryRegion *address_space, hwaddr base, 
+SoftintState *softint_mm_init(MemoryRegion *address_space, hwaddr base,
                     qemu_irq irq, MemoryRegion *main_mem, CPURISCVState *env,
-                    const char * name);
+                    const char *name);
 
 #endif

--- a/target-riscv/cpu.c
+++ b/target-riscv/cpu.c
@@ -64,7 +64,8 @@ static void riscv_cpu_reset(CPUState *s)
     cpu_state_reset(env);
 }
 
-static void riscv_cpu_disas_set_info(CPUState *s, disassemble_info *info) {
+static void riscv_cpu_disas_set_info(CPUState *s, disassemble_info *info)
+{
     info->print_insn = print_insn_riscv;
 }
 
@@ -119,8 +120,8 @@ static void riscv_cpu_class_init(ObjectClass *c, void *data)
     cc->do_unassigned_access = riscv_cpu_unassigned_access;
     cc->do_unaligned_access = riscv_cpu_do_unaligned_access;
     cc->get_phys_page_debug = riscv_cpu_get_phys_page_debug;
-    // TODO to support migration:
-    // cc->vmsd = &vmstate_riscv_cpu;
+    /* TODO to support migration:
+       cc->vmsd = &vmstate_riscv_cpu; */
 #endif
 
     cc->disas_set_info = riscv_cpu_disas_set_info;

--- a/target-riscv/cpu.h
+++ b/target-riscv/cpu.h
@@ -1,11 +1,11 @@
-#if !defined (__RISCV_CPU_H__)
+#if !defined(__RISCV_CPU_H__)
 #define __RISCV_CPU_H__
 
-//#define DEBUG_OP
+/*#define DEBUG_OP */
 
 #define TARGET_HAS_ICE 1
 
-#define ELF_MACHINE	EM_RISCV
+#define ELF_MACHINE EM_RISCV
 
 #define CPUArchState struct CPURISCVState
 
@@ -13,14 +13,14 @@
 
 #include "qemu-common.h"
 
-// QEMU addressing/paging config
-#define TARGET_PAGE_BITS 12 // 4 KiB Pages
+/* QEMU addressing/paging config */
+#define TARGET_PAGE_BITS 12 /* 4 KiB Pages */
 #if defined(TARGET_RISCV64)
-#define TARGET_LONG_BITS 64 // this defs TCGv as TCGv_i64 in tcg/tcg-op.h
+#define TARGET_LONG_BITS 64 /* this defs TCGv as TCGv_i64 in tcg/tcg-op.h */
 #define TARGET_PHYS_ADDR_SPACE_BITS 50
 #define TARGET_VIRT_ADDR_SPACE_BITS 39
 #elif defined(TARGET_RISCV32)
-#define TARGET_LONG_BITS 32 // this defs TCGv as TCGv_i64 in tcg/tcg-op.h
+#define TARGET_LONG_BITS 32 /* this defs TCGv as TCGv_i64 in tcg/tcg-op.h */
 #define TARGET_PHYS_ADDR_SPACE_BITS 34
 #define TARGET_VIRT_ADDR_SPACE_BITS 32
 #endif
@@ -37,11 +37,14 @@ struct CPURISCVState;
 
 #define PGSHIFT 12
 
-// uncomment for lots of debug printing
-// #define RISCV_DEBUG_PRINT
+/* uncomment for lots of debug printing */
+/* #define RISCV_DEBUG_PRINT */
 
-#define get_field(reg, mask) (((reg) & (target_ulong)(mask)) / ((mask) & ~((mask) << 1)))
-#define set_field(reg, mask, val) (((reg) & ~(target_ulong)(mask)) | (((target_ulong)(val) * ((mask) & ~((mask) << 1))) & (target_ulong)(mask)))
+#define get_field(reg, mask) (((reg) & \
+                 (target_ulong)(mask)) / ((mask) & ~((mask) << 1)))
+#define set_field(reg, mask, val) (((reg) & ~(target_ulong)(mask)) | \
+                 (((target_ulong)(val) * ((mask) & ~((mask) << 1))) & \
+                 (target_ulong)(mask)))
 
 
 #define FP_RD_NE  0
@@ -132,8 +135,8 @@ struct CPURISCVState;
 #define CSR_MTIMEH 0xf81
 #define CSR_MINSTRETH 0xf82
 
-// RISCV Exception Codes
-#define EXCP_NONE                       -1   // not a real RISCV exception code
+/* RISCV Exception Codes */
+#define EXCP_NONE                       -1 /* not a real RISCV exception code */
 #define RISCV_EXCP_INST_ADDR_MIS           0x0
 #define RISCV_EXCP_INST_ACCESS_FAULT       0x1
 #define RISCV_EXCP_ILLEGAL_INST            0x2
@@ -142,12 +145,13 @@ struct CPURISCVState;
 #define RISCV_EXCP_LOAD_ACCESS_FAULT       0x5
 #define RISCV_EXCP_STORE_AMO_ADDR_MIS      0x6
 #define RISCV_EXCP_STORE_AMO_ACCESS_FAULT  0x7
-#define RISCV_EXCP_U_ECALL                 0x8 // for convenience, report all
-                                                   // ECALLs as this, handler fixes
+#define RISCV_EXCP_U_ECALL                 0x8 /* for convenience, report all
+                                                  ECALLs as this, handler
+                                                  fixes */
 #define RISCV_EXCP_S_ECALL                 0x9
 #define RISCV_EXCP_H_ECALL                 0xa
 #define RISCV_EXCP_M_ECALL                 0xb
-// interrupts not listed here
+/* interrupts not listed here */
 
 #define IS_RV_INTERRUPT(ival) (ival & (0x1 << 31))
 
@@ -183,21 +187,21 @@ struct CPURISCVState;
 #define SSTATUS32_SD        0x80000000
 #define SSTATUS64_SD        0x8000000000000000
 
-#define DCSR_XDEBUGVER      (3U<<30)
-#define DCSR_NDRESET        (1<<29)
-#define DCSR_FULLRESET      (1<<28)
-#define DCSR_HWBPCOUNT      (0xfff<<16)
-#define DCSR_EBREAKM        (1<<15)
-#define DCSR_EBREAKH        (1<<14)
-#define DCSR_EBREAKS        (1<<13)
-#define DCSR_EBREAKU        (1<<12)
-#define DCSR_STOPCYCLE      (1<<10)
-#define DCSR_STOPTIME       (1<<9)
-#define DCSR_CAUSE          (7<<6)
-#define DCSR_DEBUGINT       (1<<5)
-#define DCSR_HALT           (1<<3)
-#define DCSR_STEP           (1<<2)
-#define DCSR_PRV            (3<<0)
+#define DCSR_XDEBUGVER      (3U << 30)
+#define DCSR_NDRESET        (1 << 29)
+#define DCSR_FULLRESET      (1 << 28)
+#define DCSR_HWBPCOUNT      (0xfff << 16)
+#define DCSR_EBREAKM        (1 << 15)
+#define DCSR_EBREAKH        (1 << 14)
+#define DCSR_EBREAKS        (1 << 13)
+#define DCSR_EBREAKU        (1 << 12)
+#define DCSR_STOPCYCLE      (1 << 10)
+#define DCSR_STOPTIME       (1 << 9)
+#define DCSR_CAUSE          (7 << 6)
+#define DCSR_DEBUGINT       (1 << 5)
+#define DCSR_HALT           (1 << 3)
+#define DCSR_STEP           (1 << 2)
+#define DCSR_PRV            (3 << 0)
 
 #define DCSR_CAUSE_NONE     0
 #define DCSR_CAUSE_SWBP     1
@@ -242,7 +246,7 @@ struct CPURISCVState;
 #define IRQ_M_EXT    11
 #define IRQ_COP      12
 #define IRQ_HOST     13
- 
+
 #define DEFAULT_RSTVEC     0x00001000
 #define DEFAULT_NMIVEC     0x00001004
 #define DEFAULT_MTVEC      0x00001010
@@ -250,7 +254,7 @@ struct CPURISCVState;
 #define EXT_IO_BASE        0x40000000
 #define DRAM_BASE          0x80000000
 
-// breakpoint control fields
+/* breakpoint control fields */
 #define BPCONTROL_X           0x00000001
 #define BPCONTROL_W           0x00000002
 #define BPCONTROL_R           0x00000004
@@ -262,17 +266,17 @@ struct CPURISCVState;
 #define BPCONTROL_BPAMASKMAX 0x0F80000000000000
 #define BPCONTROL_TDRTYPE    0xF000000000000000
 
-// page table entry (PTE) fields
-#define PTE_V     0x001 // Valid
-#define PTE_R     0x002 // Read
-#define PTE_W     0x004 // Write
-#define PTE_X     0x008 // Execute
-#define PTE_U     0x010 // User
-#define PTE_G     0x020 // Global
-#define PTE_A     0x040 // Accessed
-#define PTE_D     0x080 // Dirty
-#define PTE_SOFT  0x300 // Reserved for Software
- 
+/* page table entry (PTE) fields */
+#define PTE_V     0x001 /* Valid */
+#define PTE_R     0x002 /* Read */
+#define PTE_W     0x004 /* Write */
+#define PTE_X     0x008 /* Execute */
+#define PTE_U     0x010 /* User */
+#define PTE_G     0x020 /* Global */
+#define PTE_A     0x040 /* Accessed */
+#define PTE_D     0x080 /* Dirty */
+#define PTE_SOFT  0x300 /* Reserved for Software */
+
 #define PTE_PPN_SHIFT 10
 
 #define PTE_TABLE(PTE) (((PTE) & (PTE_V | PTE_R | PTE_W | PTE_X)) == PTE_V)
@@ -282,21 +286,21 @@ typedef struct riscv_def_t riscv_def_t;
 typedef struct CPURISCVState CPURISCVState;
 struct CPURISCVState {
     target_ulong gpr[32];
-    uint64_t fpr[32]; // TODO: width dep on F or D extension
+    uint64_t fpr[32]; /* TODO: width dep on F or D extension */
     target_ulong PC;
     target_ulong load_reservation;
 
-    target_ulong csr[4096]; // RISCV CSR registers
+    target_ulong csr[4096]; /* RISCV CSR registers */
     target_ulong priv;
     target_ulong badaddr;
 
-    // temporary htif regs
+    /* temporary htif regs */
     uint64_t mfromhost;
     uint64_t mtohost;
 
     uint64_t timecmp;
 
-    // backup in machine.c?
+    /* backup in machine.c? */
     float_status fp_status;
 
     /* QEMU */
@@ -369,7 +373,7 @@ hwaddr riscv_cpu_get_phys_page_debug(CPUState *cpu, vaddr addr);
 int riscv_cpu_gdb_read_register(CPUState *cpu, uint8_t *buf, int reg);
 int riscv_cpu_gdb_write_register(CPUState *cpu, uint8_t *buf, int reg);
 bool riscv_cpu_exec_interrupt(CPUState *cs, int interrupt_request);
-void  riscv_cpu_do_unaligned_access(CPUState *cs, vaddr addr, 
+void  riscv_cpu_do_unaligned_access(CPUState *cs, vaddr addr,
                                         MMUAccessType access_type,
                                         int mmu_idx, uintptr_t retaddr);
 #endif
@@ -379,18 +383,18 @@ void riscv_cpu_unassigned_access(CPUState *cpu, hwaddr addr, bool is_write,
         bool is_exec, int unused, unsigned size);
 #endif
 
-void riscv_cpu_list (FILE *f, fprintf_function cpu_fprintf);
+void riscv_cpu_list(FILE *f, fprintf_function cpu_fprintf);
 
 #define cpu_signal_handler cpu_riscv_signal_handler
 #define cpu_list riscv_cpu_list
 
-static inline int cpu_mmu_index (CPURISCVState *env, bool ifetch)
+static inline int cpu_mmu_index(CPURISCVState *env, bool ifetch)
 {
     target_ulong mode = env->priv;
     if (!ifetch) {
-         if(get_field(env->csr[CSR_MSTATUS], MSTATUS_MPRV)) {
-             mode = get_field(env->csr[CSR_MSTATUS], MSTATUS_MPP);
-         }
+        if (get_field(env->csr[CSR_MSTATUS], MSTATUS_MPRV)) {
+            mode = get_field(env->csr[CSR_MSTATUS], MSTATUS_MPP);
+        }
     }
     if (get_field(env->csr[CSR_MSTATUS], MSTATUS_VM) == VM_MBARE) {
         mode = PRV_M;
@@ -402,11 +406,13 @@ static int ctz(target_ulong val);
 
 static int ctz(target_ulong val)
 {
-  int res = 0;
-  if (val)
-    while ((val & 1) == 0)
-      val >>= 1, res++;
-  return res;
+    int res = 0;
+    if (val) {
+        while ((val & 1) == 0) {
+            val >>= 1, res++;
+        }
+    }
+    return res;
 }
 
 /*
@@ -420,33 +426,35 @@ static inline int cpu_riscv_hw_interrupts_pending(CPURISCVState *env)
 
     target_ulong mie = get_field(env->csr[CSR_MSTATUS], MSTATUS_MIE);
     target_ulong m_enabled = env->priv < PRV_M || (env->priv == PRV_M && mie);
-    target_ulong enabled_interrupts = pending_interrupts & ~env->csr[CSR_MIDELEG] & -m_enabled;
+    target_ulong enabled_interrupts = pending_interrupts &
+                                      ~env->csr[CSR_MIDELEG] & -m_enabled;
 
     target_ulong sie = get_field(env->csr[CSR_MSTATUS], MSTATUS_SIE);
     target_ulong s_enabled = env->priv < PRV_S || (env->priv == PRV_S && sie);
-    enabled_interrupts |= pending_interrupts & env->csr[CSR_MIDELEG] & -s_enabled;
+    enabled_interrupts |= pending_interrupts & env->csr[CSR_MIDELEG] &
+                          -s_enabled;
 
     if (enabled_interrupts) {
         target_ulong counted = ctz(enabled_interrupts);
         if (counted == IRQ_HOST) {
-            // we're handing it to the cpu now, so get rid of the qemu irq
-            qemu_irq_lower(env->irq[4]); // get rid of the irq request
+            /* we're handing it to the cpu now, so get rid of the qemu irq */
+            qemu_irq_lower(env->irq[4]); /* get rid of the irq request */
         } else if (counted == IRQ_M_TIMER) {
-            // we're handing it to the cpu now, so get rid of the qemu irq
-            qemu_irq_lower(env->irq[7]); // get rid of the irq request
+            /* we're handing it to the cpu now, so get rid of the qemu irq */
+            qemu_irq_lower(env->irq[7]); /* get rid of the irq request */
         } else if (counted == IRQ_S_TIMER || counted == IRQ_H_TIMER) {
-            // don't lower irq here
+            /* don't lower irq here */
         }
         return counted;
     } else {
-        // indicates no pending interrupt to handler in cpu-exec.c
+        /* indicates no pending interrupt to handler in cpu-exec.c */
         return -1;
     }
 }
 
 #include "exec/cpu-all.h"
 
-//int cpu_riscv_exec(CPUState *cpu);
+/*int cpu_riscv_exec(CPUState *cpu); */
 void riscv_tcg_init(void);
 RISCVCPU *cpu_riscv_init(const char *cpu_model);
 int cpu_riscv_signal_handler(int host_signum, void *pinfo, void *puc);
@@ -466,8 +474,8 @@ void cpu_riscv_soft_irq(CPURISCVState *env, int irq, int level);
 int riscv_cpu_handle_mmu_fault(CPUState *cpu, vaddr address, MMUAccessType rw,
                               int mmu_idx);
 #if !defined(CONFIG_USER_ONLY)
-hwaddr cpu_riscv_translate_address (CPURISCVState *env, target_ulong address,
-		                               int rw);
+hwaddr cpu_riscv_translate_address(CPURISCVState *env, target_ulong address,
+                                   int rw);
 #endif
 
 static inline void cpu_get_tb_cpu_state(CPURISCVState *env, target_ulong *pc,
@@ -475,7 +483,7 @@ static inline void cpu_get_tb_cpu_state(CPURISCVState *env, target_ulong *pc,
 {
     *pc = env->PC;
     *cs_base = 0;
-    *flags = 0; // necessary to avoid compiler warning
+    *flags = 0; /* necessary to avoid compiler warning */
 }
 
 #ifndef CONFIG_USER_ONLY

--- a/target-riscv/gdbstub.c
+++ b/target-riscv/gdbstub.c
@@ -23,9 +23,9 @@
 #include "exec/gdbstub.h"
 #include "cpu.h"
 
-// TODO: fix after priv 1.9 bump
+/* TODO: fix after priv 1.9 bump */
 
-// map to CSR NOs for GDB
+/* map to CSR NOs for GDB */
 /*int indexed_csrs[] = {
     CSR_FFLAGS,
     CSR_FRM,
@@ -98,7 +98,7 @@
 
 int riscv_cpu_gdb_read_register(CPUState *cs, uint8_t *mem_buf, int n)
 {
-    /*
+#if 0
     RISCVCPU *cpu = RISCV_CPU(cs);
     CPURISCVState *env = &cpu->env;
     int target_csrno;
@@ -108,19 +108,18 @@ int riscv_cpu_gdb_read_register(CPUState *cs, uint8_t *mem_buf, int n)
     } else if (n == 32) {
         return gdb_get_regl(mem_buf, env->PC);
     } else if (n < 65) {
-        return gdb_get_regl(mem_buf, env->fpr[n-33]);
+        return gdb_get_regl(mem_buf, env->fpr[n - 33]);
     } else if (n < 132) {
         n -= 65;
         target_csrno = indexed_csrs[n];
-        switch (target_csrno) 
-        {
-        // 32-bit wide 
+        switch (target_csrno) {
+        /* 32-bit wide  */
         case CSR_FFLAGS:
         case CSR_FRM:
         case CSR_FCSR:
             return gdb_get_reg32(mem_buf, csr_read_helper(env, target_csrno));
 
-        // unused on RV64 or not implemented
+        /* unused on RV64 or not implemented */
         case CSR_MTIMEH:
         case CSR_STIMEH:
         case CSR_STIMEHW:
@@ -135,17 +134,17 @@ int riscv_cpu_gdb_read_register(CPUState *cs, uint8_t *mem_buf, int n)
         case CSR_MTIMECMPH:
             return gdb_get_regl(mem_buf, 0L);
 
-        // special MFROMHOST, MTOHOST
+        /* special MFROMHOST, MTOHOST */
         case CSR_MFROMHOST:
         case CSR_MTOHOST:
             return gdb_get_regl(mem_buf, env->csr[target_csrno]);
 
-        // all others
+        /* all others */
         default:
             return gdb_get_regl(mem_buf, csr_read_helper(env, target_csrno));
         }
     }
-    */
+#endif
     return 0;
 }
 

--- a/target-riscv/helper.c
+++ b/target-riscv/helper.c
@@ -105,7 +105,7 @@ static int get_physical_address(CPURISCVState *env, hwaddr *physical,
     }
 
     if (mode == PRV_M) {
-        target_ulong msb_mask = (2L << (TARGET_LONG_BITS - 1)) - 1;
+        target_ulong msb_mask = (2UL << (TARGET_LONG_BITS - 1)) - 1;
                                         /*0x7FFFFFFFFFFFFFFF; */
         *physical = address & msb_mask;
         *prot = PAGE_READ | PAGE_WRITE | PAGE_EXEC;

--- a/target-riscv/helper.h
+++ b/target-riscv/helper.h
@@ -1,13 +1,13 @@
-// Exceptions
+/* Exceptions */
 DEF_HELPER_2(raise_exception, noreturn, env, i32)
 DEF_HELPER_1(raise_exception_debug, noreturn, env)
 DEF_HELPER_3(raise_exception_err, noreturn, env, i32, tl)
 DEF_HELPER_3(raise_exception_mbadaddr, noreturn, env, i32, tl)
 
-// MULHSU helper
+/* MULHSU helper */
 DEF_HELPER_3(mulhsu, tl, env, tl, tl)
 
-// Floating Point - fused
+/* Floating Point - fused */
 DEF_HELPER_5(fmadd_s, i64, env, i64, i64, i64, i64)
 DEF_HELPER_5(fmadd_d, i64, env, i64, i64, i64, i64)
 DEF_HELPER_5(fmsub_s, i64, env, i64, i64, i64, i64)
@@ -17,7 +17,7 @@ DEF_HELPER_5(fnmsub_d, i64, env, i64, i64, i64, i64)
 DEF_HELPER_5(fnmadd_s, i64, env, i64, i64, i64, i64)
 DEF_HELPER_5(fnmadd_d, i64, env, i64, i64, i64, i64)
 
-// Floating Point - Single Precision
+/* Floating Point - Single Precision */
 DEF_HELPER_4(fadd_s, i64, env, i64, i64, i64)
 DEF_HELPER_4(fsub_s, i64, env, i64, i64, i64)
 DEF_HELPER_4(fmul_s, i64, env, i64, i64, i64)
@@ -45,7 +45,7 @@ DEF_HELPER_3(fcvt_s_lu, i64, env, i64, i64)
 #endif
 DEF_HELPER_2(fclass_s, tl, env, i64)
 
-// Floating Point - Double Precision
+/* Floating Point - Double Precision */
 DEF_HELPER_4(fadd_d, i64, env, i64, i64, i64)
 DEF_HELPER_4(fsub_d, i64, env, i64, i64, i64)
 DEF_HELPER_4(fmul_d, i64, env, i64, i64, i64)

--- a/target-riscv/instmap.h
+++ b/target-riscv/instmap.h
@@ -52,7 +52,8 @@ enum {
     OPC_RISC_FP_ARITH = (0x53),
 };
 
-#define MASK_OP_ARITH(op)   (MASK_OP_MAJOR(op) | (op & ((0x7 << 12) | (0x7F << 25))))
+#define MASK_OP_ARITH(op)   (MASK_OP_MAJOR(op) | (op & ((0x7 << 12) | \
+                            (0x7F << 25))))
 enum {
     OPC_RISC_ADD   = OPC_RISC_ARITH | (0x0 << 12) | (0x00 << 25),
     OPC_RISC_SUB   = OPC_RISC_ARITH | (0x0 << 12) | (0x20 << 25),
@@ -86,8 +87,9 @@ enum {
     OPC_RISC_XORI   = OPC_RISC_ARITH_IMM | (0x4 << 12),
     OPC_RISC_ORI    = OPC_RISC_ARITH_IMM | (0x6 << 12),
     OPC_RISC_ANDI   = OPC_RISC_ARITH_IMM | (0x7 << 12),
-    OPC_RISC_SLLI   = OPC_RISC_ARITH_IMM | (0x1 << 12), // additional part of IMM
-    OPC_RISC_SHIFT_RIGHT_I = OPC_RISC_ARITH_IMM | (0x5 << 12) // SRAI, SRLI
+    OPC_RISC_SLLI   = OPC_RISC_ARITH_IMM | (0x1 << 12), /* additional part of
+                                                           IMM */
+    OPC_RISC_SHIFT_RIGHT_I = OPC_RISC_ARITH_IMM | (0x5 << 12) /* SRAI, SRLI */
 };
 
 #define MASK_OP_BRANCH(op)     (MASK_OP_MAJOR(op) | (op & (0x7 << 12)))
@@ -103,11 +105,14 @@ enum {
 #define MASK_OP_ARITH_IMM_W(op)   (MASK_OP_MAJOR(op) | (op & (0x7 << 12)))
 enum {
     OPC_RISC_ADDIW   = OPC_RISC_ARITH_IMM_W | (0x0 << 12),
-    OPC_RISC_SLLIW   = OPC_RISC_ARITH_IMM_W | (0x1 << 12), // additional part of IMM
-    OPC_RISC_SHIFT_RIGHT_IW = OPC_RISC_ARITH_IMM_W | (0x5 << 12) // SRAI, SRLI
+    OPC_RISC_SLLIW   = OPC_RISC_ARITH_IMM_W | (0x1 << 12), /* additional part of
+                                                              IMM */
+    OPC_RISC_SHIFT_RIGHT_IW = OPC_RISC_ARITH_IMM_W | (0x5 << 12) /* SRAI, SRLI
+                                                                  */
 };
 
-#define MASK_OP_ARITH_W(op)   (MASK_OP_MAJOR(op) | (op & ((0x7 << 12) | (0x7F << 25))))
+#define MASK_OP_ARITH_W(op)   (MASK_OP_MAJOR(op) | (op & ((0x7 << 12) \
+                              | (0x7F << 25))))
 enum {
     OPC_RISC_ADDW   = OPC_RISC_ARITH_W | (0x0 << 12) | (0x00 << 25),
     OPC_RISC_SUBW   = OPC_RISC_ARITH_W | (0x0 << 12) | (0x20 << 25),
@@ -143,10 +148,12 @@ enum {
 };
 
 #define MASK_OP_JALR(op)   (MASK_OP_MAJOR(op) | (op & (0x7 << 12)))
-// no enum since OPC_RISC_JALR is the actual value
+/* no enum since OPC_RISC_JALR is the actual value */
 
-#define MASK_OP_ATOMIC(op)   (MASK_OP_MAJOR(op) | (op & ((0x7 << 12) | (0x7F << 25))))
-#define MASK_OP_ATOMIC_NO_AQ_RL(op)   (MASK_OP_MAJOR(op) | (op & ((0x7 << 12) | (0x1F << 27))))
+#define MASK_OP_ATOMIC(op)   (MASK_OP_MAJOR(op) | (op & ((0x7 << 12) \
+                                                | (0x7F << 25))))
+#define MASK_OP_ATOMIC_NO_AQ_RL(op)   (MASK_OP_MAJOR(op) | (op & ((0x7 << 12)\
+                                                         | (0x1F << 27))))
 enum {
     OPC_RISC_LR_W        = OPC_RISC_ATOMIC | (0x2 << 12) | (0x02 << 27),
     OPC_RISC_SC_W        = OPC_RISC_ATOMIC | (0x2 << 12) | (0x03 << 27),
@@ -230,7 +237,7 @@ enum {
 
 #define MASK_OP_FP_ARITH(op)   (MASK_OP_MAJOR(op) | (op & (0x7F << 25)))
 enum {
-    // float
+    /* float */
     OPC_RISC_FADD_S    = OPC_RISC_FP_ARITH | (0x0 << 25),
     OPC_RISC_FSUB_S    = OPC_RISC_FP_ARITH | (0x4 << 25),
     OPC_RISC_FMUL_S    = OPC_RISC_FP_ARITH | (0x8 << 25),
@@ -264,7 +271,7 @@ enum {
 
     OPC_RISC_FMV_S_X   = OPC_RISC_FP_ARITH | (0x78 << 25),
 
-    // double
+    /* double */
     OPC_RISC_FADD_D    = OPC_RISC_FP_ARITH | (0x1 << 25),
     OPC_RISC_FSUB_D    = OPC_RISC_FP_ARITH | (0x5 << 25),
     OPC_RISC_FMUL_D    = OPC_RISC_FP_ARITH | (0x9 << 25),
@@ -303,9 +310,18 @@ enum {
     OPC_RISC_FMV_D_X   = OPC_RISC_FP_ARITH | (0x79 << 25),
 };
 
-#define GET_B_IMM(inst)              ((int16_t)((((inst >> 25) & 0x3F) << 5) | ((((int32_t)inst) >> 31) << 12) | (((inst >> 8) & 0xF) << 1) | (((inst >> 7) & 0x1) << 11)))  /* THIS BUILDS 13 bit imm (implicit zero is tacked on here), also note that bit #12 is obtained in a special way to get sign extension */
-#define GET_STORE_IMM(inst)           ((int16_t)(((((int32_t)inst) >> 25) << 5) | ((inst >> 7) & 0x1F)))
-#define GET_JAL_IMM(inst)             ((int32_t)((inst & 0xFF000) | (((inst >> 20) & 0x1) << 11) | (((inst >> 21) & 0x3FF) << 1) | ((((int32_t)inst) >> 31) << 20)))
-#define GET_RM(inst)                  ((inst >> 12) & 0x7)
-#define GET_RS3(inst)                 ((inst >> 27) & 0x1F)
+/* THIS BUILDS 13 bit imm (implicit zero is tacked on here), also note that bit
+   #12 is obtained in a special way to get sign extension */
+#define GET_B_IMM(inst)              ((int16_t)((((inst >> 25) & 0x3F) << 5)\
+                                     | ((((int32_t)inst) >> 31) << 12)      \
+                                     | (((inst >> 8) & 0xF) << 1)           \
+                                     | (((inst >> 7) & 0x1) << 11)))
 
+#define GET_STORE_IMM(inst)          ((int16_t)(((((int32_t)inst) >> 25) << 5)\
+                                     | ((inst >> 7) & 0x1F)))
+#define GET_JAL_IMM(inst)            ((int32_t)((inst & 0xFF000) \
+                                     | (((inst >> 20) & 0x1) << 11)\
+                                     | (((inst >> 21) & 0x3FF) << 1)\
+                                     | ((((int32_t)inst) >> 31) << 20)))
+#define GET_RM(inst)                 ((inst >> 12) & 0x7)
+#define GET_RS3(inst)                ((inst >> 27) & 0x1F)

--- a/target-riscv/translate.c
+++ b/target-riscv/translate.c
@@ -29,15 +29,15 @@
 
 #include "instmap.h"
 
-//#define DISABLE_CHAINING_BRANCH
-//#define DISABLE_CHAINING_JAL
+/*#define DISABLE_CHAINING_BRANCH */
+/*#define DISABLE_CHAINING_JAL */
 
 #define RISCV_DEBUG_DISAS 0
 
 /* global register indices */
 static TCGv_ptr cpu_env;
 static TCGv cpu_gpr[32], cpu_PC;
-static TCGv_i64 cpu_fpr[32]; // TODO: set width based on F or D extension
+static TCGv_i64 cpu_fpr[32]; /* TODO: set width based on F or D extension */
 static TCGv load_reservation;
 
 #include "exec/gen-icount.h"
@@ -54,10 +54,10 @@ typedef struct DisasContext {
 static inline void kill_unknown(DisasContext *ctx, int excp);
 
 enum {
-    BS_NONE     = 0, // When seen outside of translation while loop, indicates
-                     // need to exit tb due to end of page.
-    BS_STOP     = 1, // Need to exit tb for syscall, sret, etc.
-    BS_BRANCH   = 2, // Need to exit tb for branch, jal, etc.
+    BS_NONE     = 0, /* When seen outside of translation while loop, indicates*/
+                     /* need to exit tb due to end of page. */
+    BS_STOP     = 1, /* Need to exit tb for syscall, sret, etc. */
+    BS_BRANCH   = 2, /* Need to exit tb for branch, jal, etc. */
 };
 
 static const char * const regnames[] = {
@@ -90,7 +90,7 @@ static const char * const fpr_regnames[] = {
         }                                                                     \
     } while (0)
 
-static inline void generate_exception (DisasContext *ctx, int excp)
+static inline void generate_exception(DisasContext *ctx, int excp)
 {
     tcg_gen_movi_tl(cpu_PC, ctx->pc);
     TCGv_i32 helper_tmp = tcg_const_i32(excp);
@@ -106,7 +106,7 @@ static inline void generate_exception_mbadaddr(DisasContext *ctx, int excp)
     tcg_temp_free_i32(helper_tmp);
 }
 
-static inline void generate_exception_err (DisasContext *ctx, int excp)
+static inline void generate_exception_err(DisasContext *ctx, int excp)
 {
     tcg_gen_movi_tl(cpu_PC, ctx->pc);
     TCGv_i32 helper_tmp = tcg_const_i32(excp);
@@ -115,8 +115,9 @@ static inline void generate_exception_err (DisasContext *ctx, int excp)
 }
 
 
-// unknown instruction / fp disabled
-static inline void kill_unknown(DisasContext *ctx, int excp) {
+/* unknown instruction / fp disabled */
+static inline void kill_unknown(DisasContext *ctx, int excp)
+{
     generate_exception(ctx, excp);
     ctx->bstate = BS_STOP;
 }
@@ -127,10 +128,10 @@ static inline void gen_goto_tb(DisasContext *ctx, int n, target_ulong dest)
     tb = ctx->tb;
     if ((tb->pc & TARGET_PAGE_MASK) == (dest & TARGET_PAGE_MASK) &&
         likely(!ctx->singlestep_enabled)) {
-        // we only allow direct chaining when the jump is to the same page
-        // otherwise, we could produce incorrect chains when address spaces
-        // change. see
-        // http://lists.gnu.org/archive/html/qemu-devel/2007-06/msg00213.html
+        /* we only allow direct chaining when the jump is to the same page
+           otherwise, we could produce incorrect chains when address spaces
+           change. see
+           http://lists.gnu.org/archive/html/qemu-devel/2007-06/msg00213.html */
         tcg_gen_goto_tb(n);
         tcg_gen_movi_tl(cpu_PC, dest);
         tcg_gen_exit_tb((uintptr_t)tb + n);
@@ -146,7 +147,7 @@ static inline void gen_goto_tb(DisasContext *ctx, int n, target_ulong dest)
 /* Wrapper for getting reg values - need to check of reg is zero since
  * cpu_gpr[0] is not actually allocated
  */
-static inline void gen_get_gpr (TCGv t, int reg_num)
+static inline void gen_get_gpr(TCGv t, int reg_num)
 {
     if (reg_num == 0) {
         tcg_gen_movi_tl(t, 0);
@@ -160,15 +161,15 @@ static inline void gen_get_gpr (TCGv t, int reg_num)
  * since we usually avoid calling the OP_TYPE_gen function if we see a write to
  * $zero
  */
-static inline void gen_set_gpr (int reg_num_dst, TCGv t)
+static inline void gen_set_gpr(int reg_num_dst, TCGv t)
 {
     if (reg_num_dst != 0) {
         tcg_gen_mov_tl(cpu_gpr[reg_num_dst], t);
     }
 }
 
-inline static void gen_arith(DisasContext *ctx, uint32_t opc,
-                      int rd, int rs1, int rs2)
+static inline void gen_arith(DisasContext *ctx, uint32_t opc,
+                             int rd, int rs1, int rs2)
 {
     TCGv source1, source2;
 
@@ -187,7 +188,7 @@ inline static void gen_arith(DisasContext *ctx, uint32_t opc,
         tcg_gen_sub_tl(source1, source1, source2);
         break;
     case OPC_RISC_SLL:
-        tcg_gen_andi_tl(source2, source2, TARGET_LONG_BITS-1);
+        tcg_gen_andi_tl(source2, source2, TARGET_LONG_BITS - 1);
         tcg_gen_shl_tl(source1, source1, source2);
         break;
     case OPC_RISC_SLT:
@@ -200,11 +201,11 @@ inline static void gen_arith(DisasContext *ctx, uint32_t opc,
         tcg_gen_xor_tl(source1, source1, source2);
         break;
     case OPC_RISC_SRL:
-        tcg_gen_andi_tl(source2, source2, TARGET_LONG_BITS-1);
+        tcg_gen_andi_tl(source2, source2, TARGET_LONG_BITS - 1);
         tcg_gen_shr_tl(source1, source1, source2);
         break;
     case OPC_RISC_SRA:
-        tcg_gen_andi_tl(source2, source2, TARGET_LONG_BITS-1);
+        tcg_gen_andi_tl(source2, source2, TARGET_LONG_BITS - 1);
         tcg_gen_sar_tl(source1, source1, source2);
         break;
     case OPC_RISC_OR:
@@ -229,9 +230,9 @@ inline static void gen_arith(DisasContext *ctx, uint32_t opc,
         {
             TCGv spec_source1, spec_source2;
             TCGv cond1, cond2;
-            TCGLabel* handle_zero = gen_new_label();
-            TCGLabel* handle_overflow = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *handle_zero = gen_new_label();
+            TCGLabel *handle_overflow = gen_new_label();
+            TCGLabel *done = gen_new_label();
             spec_source1 = tcg_temp_local_new();
             spec_source2 = tcg_temp_local_new();
             cond1 = tcg_temp_local_new();
@@ -241,23 +242,27 @@ inline static void gen_arith(DisasContext *ctx, uint32_t opc,
             gen_get_gpr(spec_source2, rs2);
             tcg_gen_brcondi_tl(TCG_COND_EQ, spec_source2, 0x0, handle_zero);
 
-            // now, use temp reg to check if both overflow conditions satisfied
-            tcg_gen_setcondi_tl(TCG_COND_EQ, cond2, spec_source2, (target_ulong)0xFFFFFFFFFFFFFFFF); // divisor = -1
-            tcg_gen_setcondi_tl(TCG_COND_EQ, cond1, spec_source1, 1L << (TARGET_LONG_BITS-1));
+            /* now, use temp reg to check if both overflow conditions
+               satisfied */
+            tcg_gen_setcondi_tl(TCG_COND_EQ, cond2, spec_source2,
+                               (target_ulong)0xFFFFFFFFFFFFFFFF);
+                               /* divisor = -1 */
+            tcg_gen_setcondi_tl(TCG_COND_EQ, cond1, spec_source1,
+                                1L << (TARGET_LONG_BITS - 1));
             tcg_gen_and_tl(cond1, cond1, cond2);
 
             tcg_gen_brcondi_tl(TCG_COND_EQ, cond1, 1, handle_overflow);
-            // normal case
+            /* normal case */
             tcg_gen_div_tl(spec_source1, spec_source1, spec_source2);
             tcg_gen_br(done);
-            // special zero case
+            /* special zero case */
             gen_set_label(handle_zero);
             tcg_gen_movi_tl(spec_source1, (target_ulong)0xFFFFFFFFFFFFFFFF);
             tcg_gen_br(done);
-            // special overflow case
+            /* special overflow case */
             gen_set_label(handle_overflow);
-            tcg_gen_movi_tl(spec_source1, 1L << (TARGET_LONG_BITS-1));
-            // done
+            tcg_gen_movi_tl(spec_source1, 1L << (TARGET_LONG_BITS - 1));
+            /* done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, spec_source1);
             tcg_temp_free(spec_source1);
@@ -269,8 +274,8 @@ inline static void gen_arith(DisasContext *ctx, uint32_t opc,
     case OPC_RISC_DIVU:
         {
             TCGv spec_source1, spec_source2;
-            TCGLabel* handle_zero = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *handle_zero = gen_new_label();
+            TCGLabel *done = gen_new_label();
             spec_source1 = tcg_temp_local_new();
             spec_source2 = tcg_temp_local_new();
 
@@ -278,14 +283,14 @@ inline static void gen_arith(DisasContext *ctx, uint32_t opc,
             gen_get_gpr(spec_source2, rs2);
             tcg_gen_brcondi_tl(TCG_COND_EQ, spec_source2, 0x0, handle_zero);
 
-            // normal case
+            /* normal case */
             tcg_gen_divu_tl(spec_source1, spec_source1, spec_source2);
             tcg_gen_br(done);
-            // special zero case
+            /* special zero case */
             gen_set_label(handle_zero);
             tcg_gen_movi_tl(spec_source1, (target_ulong)0xFFFFFFFFFFFFFFFF);
             tcg_gen_br(done);
-            // done
+            /* done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, spec_source1);
             tcg_temp_free(spec_source1);
@@ -296,9 +301,9 @@ inline static void gen_arith(DisasContext *ctx, uint32_t opc,
         {
             TCGv spec_source1, spec_source2;
             TCGv cond1, cond2;
-            TCGLabel* handle_zero = gen_new_label();
-            TCGLabel* handle_overflow = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *handle_zero = gen_new_label();
+            TCGLabel *handle_overflow = gen_new_label();
+            TCGLabel *done = gen_new_label();
             spec_source1 = tcg_temp_local_new();
             spec_source2 = tcg_temp_local_new();
             cond1 = tcg_temp_local_new();
@@ -308,23 +313,29 @@ inline static void gen_arith(DisasContext *ctx, uint32_t opc,
             gen_get_gpr(spec_source2, rs2);
             tcg_gen_brcondi_tl(TCG_COND_EQ, spec_source2, 0x0, handle_zero);
 
-            // now, use temp reg to check if both overflow conditions satisfied
-            tcg_gen_setcondi_tl(TCG_COND_EQ, cond2, spec_source2, (target_ulong)0xFFFFFFFFFFFFFFFF); // divisor = -1
-            tcg_gen_setcondi_tl(TCG_COND_EQ, cond1, spec_source1, 1L << (TARGET_LONG_BITS-1));
+            /* now, use temp reg to check if both overflow conditions
+               satisfied */
+            tcg_gen_setcondi_tl(TCG_COND_EQ, cond2, spec_source2,
+                               (target_ulong)0xFFFFFFFFFFFFFFFF);
+                               /* divisor = -1 */
+            tcg_gen_setcondi_tl(TCG_COND_EQ, cond1, spec_source1,
+                                1L << (TARGET_LONG_BITS - 1));
             tcg_gen_and_tl(cond1, cond1, cond2);
 
             tcg_gen_brcondi_tl(TCG_COND_EQ, cond1, 1, handle_overflow);
-            // normal case
+            /* normal case */
             tcg_gen_rem_tl(spec_source1, spec_source1, spec_source2);
             tcg_gen_br(done);
-            // special zero case
+            /* special zero case */
             gen_set_label(handle_zero);
-            tcg_gen_mov_tl(spec_source1, spec_source1); // even though it's a nop, just for clarity
+            tcg_gen_mov_tl(spec_source1, spec_source1); /* even though it's a
+                                                           nop, just for
+                                                           clarity */
             tcg_gen_br(done);
-            // special overflow case
+            /* special overflow case */
             gen_set_label(handle_overflow);
             tcg_gen_movi_tl(spec_source1, 0);
-            // done
+            /* done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, spec_source1);
             tcg_temp_free(spec_source1);
@@ -336,8 +347,8 @@ inline static void gen_arith(DisasContext *ctx, uint32_t opc,
     case OPC_RISC_REMU:
         {
             TCGv spec_source1, spec_source2;
-            TCGLabel* handle_zero = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *handle_zero = gen_new_label();
+            TCGLabel *done = gen_new_label();
             spec_source1 = tcg_temp_local_new();
             spec_source2 = tcg_temp_local_new();
 
@@ -345,14 +356,16 @@ inline static void gen_arith(DisasContext *ctx, uint32_t opc,
             gen_get_gpr(spec_source2, rs2);
             tcg_gen_brcondi_tl(TCG_COND_EQ, spec_source2, 0x0, handle_zero);
 
-            // normal case
+            /* normal case */
             tcg_gen_remu_tl(spec_source1, spec_source1, spec_source2);
             tcg_gen_br(done);
-            // special zero case
+            /* special zero case */
             gen_set_label(handle_zero);
-            tcg_gen_mov_tl(spec_source1, spec_source1); // even though it's a nop, just for clarity
+            tcg_gen_mov_tl(spec_source1, spec_source1); /* even though it's a
+                                                         * nop, just for clarity
+                                                         */
             tcg_gen_br(done);
-            // done
+            /* done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, spec_source1);
             tcg_temp_free(spec_source1);
@@ -365,15 +378,15 @@ inline static void gen_arith(DisasContext *ctx, uint32_t opc,
 
     }
 
-    // set and free
+    /* set and free */
     gen_set_gpr(rd, source1);
     tcg_temp_free(source1);
     tcg_temp_free(source2);
 }
 
 /* lower 12 bits of imm are valid */
-inline static void gen_arith_imm(DisasContext *ctx, uint32_t opc,
-                      int rd, int rs1, int16_t imm)
+static inline void gen_arith_imm(DisasContext *ctx, uint32_t opc,
+                                 int rd, int rs1, int16_t imm)
 {
     TCGv source1;
     source1 = tcg_temp_new();
@@ -407,10 +420,10 @@ inline static void gen_arith_imm(DisasContext *ctx, uint32_t opc,
         }
         break;
     case OPC_RISC_SHIFT_RIGHT_I:
-        // differentiate on IMM
+        /* differentiate on IMM */
         if ((uimm & 0x3ff) < TARGET_LONG_BITS) {
             if (uimm & 0x400) {
-                // SRAI
+                /* SRAI */
                 tcg_gen_sari_tl(source1, source1, uimm ^ 0x400);
             } else {
                 tcg_gen_shri_tl(source1, source1, uimm);
@@ -430,8 +443,8 @@ inline static void gen_arith_imm(DisasContext *ctx, uint32_t opc,
 
 #if defined(TARGET_RISCV64)
 /* lower 12 bits of imm are valid */
-inline static void gen_arith_imm_w(DisasContext *ctx, uint32_t opc,
-                      int rd, int rs1, int16_t imm)
+static inline void gen_arith_imm_w(DisasContext *ctx, uint32_t opc,
+                                   int rd, int rs1, int16_t imm)
 {
     TCGv source1;
     source1 = tcg_temp_new();
@@ -443,26 +456,26 @@ inline static void gen_arith_imm_w(DisasContext *ctx, uint32_t opc,
         tcg_gen_addi_tl(source1, source1, uimm);
         tcg_gen_ext32s_tl(source1, source1);
         break;
-    case OPC_RISC_SLLIW: // TODO: add immediate upper bits check?
+    case OPC_RISC_SLLIW: /* TODO: add immediate upper bits check? */
         tcg_gen_shli_tl(source1, source1, uimm);
         tcg_gen_ext32s_tl(source1, source1);
         break;
-    case OPC_RISC_SHIFT_RIGHT_IW: // SRLIW, SRAIW, TODO: upper bits check
-        // differentiate on IMM
+    case OPC_RISC_SHIFT_RIGHT_IW: /* SRLIW, SRAIW, TODO: upper bits check */
+        /* differentiate on IMM */
         if (uimm & 0x400) {
-            // SRAI
-            // first, trick to get it to act like working on 32 bits:
+            /* SRAI */
+            /* first, trick to get it to act like working on 32 bits: */
             tcg_gen_shli_tl(source1, source1, 32);
-            // now shift back to the right by shamt + 32 to get proper upper
-            // bits filling
+            /* now shift back to the right by shamt + 32 to get proper upper */
+            /* bits filling */
             tcg_gen_sari_tl(source1, source1, (uimm ^ 0x400) + 32);
             tcg_gen_ext32s_tl(source1, source1);
         } else {
-            // first, trick to get it to act like working on 32 bits (get rid
-            // of upper 32):
+            /* first, trick to get it to act like working on 32 bits (get rid */
+            /* of upper 32): */
             tcg_gen_shli_tl(source1, source1, 32);
-            // now shift back to the right by shamt + 32 to get proper upper
-            // bits filling
+            /* now shift back to the right by shamt + 32 to get proper upper */
+            /* bits filling */
             tcg_gen_shri_tl(source1, source1, uimm + 32);
             tcg_gen_ext32s_tl(source1, source1);
         }
@@ -475,8 +488,8 @@ inline static void gen_arith_imm_w(DisasContext *ctx, uint32_t opc,
     tcg_temp_free(source1);
 }
 
-inline static void gen_arith_w(DisasContext *ctx, uint32_t opc,
-                      int rd, int rs1, int rs2)
+static inline void gen_arith_w(DisasContext *ctx, uint32_t opc,
+                               int rd, int rs1, int rs2)
 {
     TCGv source1, source2;
     source1 = tcg_temp_new();
@@ -499,19 +512,22 @@ inline static void gen_arith_w(DisasContext *ctx, uint32_t opc,
         tcg_gen_ext32s_tl(source1, source1);
         break;
     case OPC_RISC_SRLW:
-        tcg_gen_andi_tl(source1, source1, 0x00000000FFFFFFFFLL); // clear upper 32
+        tcg_gen_andi_tl(source1, source1,
+                        0x00000000FFFFFFFFLL); /* clear upper 32 */
         tcg_gen_andi_tl(source2, source2, 0x1F);
-        tcg_gen_shr_tl(source1, source1, source2); // do actual right shift
-        tcg_gen_ext32s_tl(source1, source1); // sign ext
+        tcg_gen_shr_tl(source1, source1, source2); /* do actual right shift */
+        tcg_gen_ext32s_tl(source1, source1); /* sign ext */
         break;
     case OPC_RISC_SRAW:
-        // first, trick to get it to act like working on 32 bits (get rid of
-        // upper 32)
-        tcg_gen_shli_tl(source1, source1, 32); // clear upper 32
-        tcg_gen_sari_tl(source1, source1, 32); // smear the sign bit into upper 32
+        /* first, trick to get it to act like working on 32 bits (get rid of */
+        /* upper 32) */
+        tcg_gen_shli_tl(source1, source1, 32); /* clear upper 32 */
+        tcg_gen_sari_tl(source1, source1, 32); /* smear the sign bit into upper
+                                                  32 */
         tcg_gen_andi_tl(source2, source2, 0x1F);
-        tcg_gen_sar_tl(source1, source1, source2); // do the actual right shift
-        tcg_gen_ext32s_tl(source1, source1); // sign ext
+        tcg_gen_sar_tl(source1, source1, source2); /* do the actual right shift
+                                                    */
+        tcg_gen_ext32s_tl(source1, source1); /* sign ext */
         break;
     case OPC_RISC_MULW:
         tcg_gen_muls2_tl(source1, source2, source1, source2);
@@ -521,9 +537,9 @@ inline static void gen_arith_w(DisasContext *ctx, uint32_t opc,
         {
             TCGv spec_source1, spec_source2;
             TCGv cond1, cond2;
-            TCGLabel* handle_zero = gen_new_label();
-            TCGLabel* handle_overflow = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *handle_zero = gen_new_label();
+            TCGLabel *handle_overflow = gen_new_label();
+            TCGLabel *done = gen_new_label();
             spec_source1 = tcg_temp_local_new();
             spec_source2 = tcg_temp_local_new();
             cond1 = tcg_temp_local_new();
@@ -536,23 +552,26 @@ inline static void gen_arith_w(DisasContext *ctx, uint32_t opc,
 
             tcg_gen_brcondi_tl(TCG_COND_EQ, spec_source2, 0x0, handle_zero);
 
-            // now, use temp reg to check if both overflow conditions satisfied
-            tcg_gen_setcondi_tl(TCG_COND_EQ, cond2, spec_source2, 0xFFFFFFFFFFFFFFFF); // divisor = -1
-            tcg_gen_setcondi_tl(TCG_COND_EQ, cond1, spec_source1, 0x8000000000000000);
+            /* now, use temp reg to check if both overflow conditions
+               satisfied */
+            tcg_gen_setcondi_tl(TCG_COND_EQ, cond2, spec_source2,
+                                0xFFFFFFFFFFFFFFFF); /* divisor = -1 */
+            tcg_gen_setcondi_tl(TCG_COND_EQ, cond1, spec_source1,
+                                0x8000000000000000);
             tcg_gen_and_tl(cond1, cond1, cond2);
 
             tcg_gen_brcondi_tl(TCG_COND_EQ, cond1, 1, handle_overflow);
-            // normal case
+            /* normal case */
             tcg_gen_div_tl(spec_source1, spec_source1, spec_source2);
             tcg_gen_br(done);
-            // special zero case
+            /* special zero case */
             gen_set_label(handle_zero);
             tcg_gen_movi_tl(spec_source1, -1);
             tcg_gen_br(done);
-            // special overflow case
+            /* special overflow case */
             gen_set_label(handle_overflow);
             tcg_gen_movi_tl(spec_source1, 0x8000000000000000);
-            // done
+            /* done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, spec_source1);
             tcg_temp_free(spec_source1);
@@ -565,8 +584,8 @@ inline static void gen_arith_w(DisasContext *ctx, uint32_t opc,
     case OPC_RISC_DIVUW:
         {
             TCGv spec_source1, spec_source2;
-            TCGLabel* handle_zero = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *handle_zero = gen_new_label();
+            TCGLabel *done = gen_new_label();
             spec_source1 = tcg_temp_local_new();
             spec_source2 = tcg_temp_local_new();
 
@@ -577,14 +596,14 @@ inline static void gen_arith_w(DisasContext *ctx, uint32_t opc,
 
             tcg_gen_brcondi_tl(TCG_COND_EQ, spec_source2, 0x0, handle_zero);
 
-            // normal case
+            /* normal case */
             tcg_gen_divu_tl(spec_source1, spec_source1, spec_source2);
             tcg_gen_br(done);
-            // special zero case
+            /* special zero case */
             gen_set_label(handle_zero);
             tcg_gen_movi_tl(spec_source1, -1);
             tcg_gen_br(done);
-            // done
+            /* done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, spec_source1);
             tcg_temp_free(spec_source1);
@@ -596,9 +615,9 @@ inline static void gen_arith_w(DisasContext *ctx, uint32_t opc,
         {
             TCGv spec_source1, spec_source2;
             TCGv cond1, cond2;
-            TCGLabel* handle_zero = gen_new_label();
-            TCGLabel* handle_overflow = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *handle_zero = gen_new_label();
+            TCGLabel *handle_overflow = gen_new_label();
+            TCGLabel *done = gen_new_label();
             spec_source1 = tcg_temp_local_new();
             spec_source2 = tcg_temp_local_new();
             cond1 = tcg_temp_local_new();
@@ -611,23 +630,28 @@ inline static void gen_arith_w(DisasContext *ctx, uint32_t opc,
 
             tcg_gen_brcondi_tl(TCG_COND_EQ, spec_source2, 0x0, handle_zero);
 
-            // now, use temp reg to check if both overflow conditions satisfied
-            tcg_gen_setcondi_tl(TCG_COND_EQ, cond2, spec_source2, 0xFFFFFFFFFFFFFFFF); // divisor = -1
-            tcg_gen_setcondi_tl(TCG_COND_EQ, cond1, spec_source1, 0x8000000000000000);
+            /* now, use temp reg to check if both overflow conditions
+               satisfied */
+            tcg_gen_setcondi_tl(TCG_COND_EQ, cond2, spec_source2,
+                                0xFFFFFFFFFFFFFFFF); /* divisor = -1 */
+            tcg_gen_setcondi_tl(TCG_COND_EQ, cond1, spec_source1,
+                                0x8000000000000000);
             tcg_gen_and_tl(cond1, cond1, cond2);
 
             tcg_gen_brcondi_tl(TCG_COND_EQ, cond1, 1, handle_overflow);
-            // normal case
+            /* normal case */
             tcg_gen_rem_tl(spec_source1, spec_source1, spec_source2);
             tcg_gen_br(done);
-            // special zero case
+            /* special zero case */
             gen_set_label(handle_zero);
-            tcg_gen_mov_tl(spec_source1, spec_source1); // even though it's a nop, just for clarity
+            tcg_gen_mov_tl(spec_source1, spec_source1); /* even though it's a
+                                                         * nop, just for clarity
+                                                         */
             tcg_gen_br(done);
-            // special overflow case
+            /* special overflow case */
             gen_set_label(handle_overflow);
             tcg_gen_movi_tl(spec_source1, 0);
-            // done
+            /* done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, spec_source1);
             tcg_temp_free(spec_source1);
@@ -640,8 +664,8 @@ inline static void gen_arith_w(DisasContext *ctx, uint32_t opc,
     case OPC_RISC_REMUW:
         {
             TCGv spec_source1, spec_source2;
-            TCGLabel* handle_zero = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *handle_zero = gen_new_label();
+            TCGLabel *done = gen_new_label();
             spec_source1 = tcg_temp_local_new();
             spec_source2 = tcg_temp_local_new();
 
@@ -651,14 +675,16 @@ inline static void gen_arith_w(DisasContext *ctx, uint32_t opc,
             tcg_gen_ext32u_tl(spec_source2, spec_source2);
 
             tcg_gen_brcondi_tl(TCG_COND_EQ, spec_source2, 0x0, handle_zero);
-            // normal case
+            /* normal case */
             tcg_gen_remu_tl(spec_source1, spec_source1, spec_source2);
             tcg_gen_br(done);
-            // special zero case
+            /* special zero case */
             gen_set_label(handle_zero);
-            tcg_gen_mov_tl(spec_source1, spec_source1); // even though it's a nop, just for clarity
+            tcg_gen_mov_tl(spec_source1, spec_source1); /* even though it's a
+                                                         * nop, just for clarity
+                                                         */
             tcg_gen_br(done);
-            // done
+            /* done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, spec_source1);
             tcg_temp_free(spec_source1);
@@ -676,11 +702,11 @@ inline static void gen_arith_w(DisasContext *ctx, uint32_t opc,
 }
 #endif
 
-inline static void gen_branch(DisasContext *ctx, uint32_t opc,
-                       int rs1, int rs2, int16_t bimm) {
-
-    // TODO: misaligned insn (see jalr)
-    TCGLabel* l = gen_new_label();
+static inline void gen_branch(DisasContext *ctx, uint32_t opc,
+                              int rs1, int rs2, int16_t bimm)
+{
+    /* TODO: misaligned insn (see jalr) */
+    TCGLabel *l = gen_new_label();
     TCGv source1, source2;
     source1 = tcg_temp_new();
     source2 = tcg_temp_new();
@@ -716,21 +742,21 @@ inline static void gen_branch(DisasContext *ctx, uint32_t opc,
     tcg_gen_movi_tl(cpu_PC, ctx->pc + 4);
     tcg_gen_exit_tb(0);
 #else
-    gen_goto_tb(ctx, 1, ctx->pc + 4); // must use this for safety
+    gen_goto_tb(ctx, 1, ctx->pc + 4); /* must use this for safety */
 #endif
-    gen_set_label(l); // branch taken
+    gen_set_label(l); /* branch taken */
 #ifdef DISABLE_CHAINING_BRANCH
     tcg_gen_movi_tl(cpu_PC, ctx->pc + ubimm);
     tcg_gen_exit_tb(0);
 #else
-    gen_goto_tb(ctx, 0, ctx->pc + ubimm); // must use this for safety
+    gen_goto_tb(ctx, 0, ctx->pc + ubimm); /* must use this for safety */
 #endif
     tcg_temp_free(source1);
     tcg_temp_free(source2);
     ctx->bstate = BS_BRANCH;
 }
 
-inline static void gen_load(DisasContext *ctx, uint32_t opc,
+static inline void gen_load(DisasContext *ctx, uint32_t opc,
                       int rd, int rs1, int16_t imm)
 {
 
@@ -740,7 +766,7 @@ inline static void gen_load(DisasContext *ctx, uint32_t opc,
     TCGv t1 = tcg_temp_new();
 
     gen_get_gpr(t0, rs1);
-    tcg_gen_addi_tl(t0, t0, uimm); //
+    tcg_gen_addi_tl(t0, t0, uimm); /* */
 
     switch (opc) {
 
@@ -781,7 +807,7 @@ inline static void gen_load(DisasContext *ctx, uint32_t opc,
 }
 
 
-inline static void gen_store(DisasContext *ctx, uint32_t opc,
+static inline void gen_store(DisasContext *ctx, uint32_t opc,
                       int rs1, int rs2, int16_t imm)
 {
     target_long uimm = (target_long)imm; /* sign ext 16->64 bits */
@@ -817,21 +843,21 @@ inline static void gen_store(DisasContext *ctx, uint32_t opc,
     tcg_temp_free(dat);
 }
 
-inline static void gen_jalr(DisasContext *ctx, uint32_t opc,
+static inline void gen_jalr(DisasContext *ctx, uint32_t opc,
                       int rd, int rs1, int16_t imm)
 {
-    TCGLabel* misaligned = gen_new_label();
-    TCGLabel* done = gen_new_label();
+    TCGLabel *misaligned = gen_new_label();
+    TCGLabel *done = gen_new_label();
     target_long uimm = (target_long)imm; /* sign ext 16->64 bits */
     TCGv t0, t1, t2, t3;
     t0 = tcg_temp_local_new();
     t1 = tcg_temp_local_new();
-    t2 = tcg_temp_local_new(); // old_pc
+    t2 = tcg_temp_local_new(); /* old_pc */
     t3 = tcg_temp_local_new();
 
     switch (opc) {
 
-    case OPC_RISC_JALR: // CANNOT HAVE CHAINING WITH JALR
+    case OPC_RISC_JALR: /* CANNOT HAVE CHAINING WITH JALR */
         gen_get_gpr(t0, rs1);
         tcg_gen_addi_tl(t0, t0, uimm);
         tcg_gen_andi_tl(t0, t0, (target_ulong)0xFFFFFFFFFFFFFFFEll);
@@ -849,7 +875,7 @@ inline static void gen_jalr(DisasContext *ctx, uint32_t opc,
         generate_exception_mbadaddr(ctx, RISCV_EXCP_INST_ADDR_MIS);
 
         gen_set_label(done);
-        tcg_gen_exit_tb(0); // exception or not, NO CHAINING FOR JALR
+        tcg_gen_exit_tb(0); /* exception or not, NO CHAINING FOR JALR */
         ctx->bstate = BS_BRANCH;
         break;
     default:
@@ -864,10 +890,10 @@ inline static void gen_jalr(DisasContext *ctx, uint32_t opc,
 
 }
 
-inline static void gen_atomic(DisasContext *ctx, uint32_t opc,
+static inline void gen_atomic(DisasContext *ctx, uint32_t opc,
                       int rd, int rs1, int rs2)
 {
-    // TODO: handle aq, rl bits? - for now just get rid of them:
+    /* TODO: handle aq, rl bits? - for now just get rid of them: */
     opc = MASK_OP_ATOMIC_NO_AQ_RL(opc);
 
     TCGv source1, source2, dat;
@@ -880,21 +906,21 @@ inline static void gen_atomic(DisasContext *ctx, uint32_t opc,
     gen_get_gpr(source2, rs2);
 
     switch (opc) {
-        // all currently implemented as non-atomics
+        /* all currently implemented as non-atomics */
     case OPC_RISC_LR_W:
-        // put addr in load_reservation
+        /* put addr in load_reservation */
         tcg_gen_mov_tl(load_reservation, source1);
         tcg_gen_qemu_ld32s(source1, source1, ctx->mem_idx);
         break;
     case OPC_RISC_SC_W: {
-        TCGLabel* fail = gen_new_label();
-        TCGLabel* done = gen_new_label();
+        TCGLabel *fail = gen_new_label();
+        TCGLabel *done = gen_new_label();
         tcg_gen_brcond_tl(TCG_COND_NE, load_reservation, source1, fail);
         tcg_gen_qemu_st32(source2, source1, ctx->mem_idx);
-        tcg_gen_movi_tl(source1, 0); //success
+        tcg_gen_movi_tl(source1, 0); /*success */
         tcg_gen_br(done);
         gen_set_label(fail);
-        tcg_gen_movi_tl(source1, 1); //fail
+        tcg_gen_movi_tl(source1, 1); /*fail */
         gen_set_label(done);
         }
         break;
@@ -933,18 +959,18 @@ inline static void gen_atomic(DisasContext *ctx, uint32_t opc,
             source1_l = tcg_temp_local_new();
             source2_l = tcg_temp_local_new();
             dat_l = tcg_temp_local_new();
-            TCGLabel* j = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *j = gen_new_label();
+            TCGLabel *done = gen_new_label();
             tcg_gen_mov_tl(source1_l, source1);
             tcg_gen_ext32s_tl(source2_l, source2);
             tcg_gen_qemu_ld32s(dat_l, source1_l, ctx->mem_idx);
             tcg_gen_brcond_tl(TCG_COND_LT, dat_l, source2_l, j);
             tcg_gen_qemu_st32(source2_l, source1_l, ctx->mem_idx);
             tcg_gen_br(done);
-            // here we store the thing on the left
+            /* here we store the thing on the left */
             gen_set_label(j);
             tcg_gen_qemu_st32(dat_l, source1_l, ctx->mem_idx);
-            //done
+            /*done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, dat_l);
             tcg_temp_free(source1_l);
@@ -958,18 +984,18 @@ inline static void gen_atomic(DisasContext *ctx, uint32_t opc,
             source1_l = tcg_temp_local_new();
             source2_l = tcg_temp_local_new();
             dat_l = tcg_temp_local_new();
-            TCGLabel* j = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *j = gen_new_label();
+            TCGLabel *done = gen_new_label();
             tcg_gen_mov_tl(source1_l, source1);
             tcg_gen_ext32s_tl(source2_l, source2);
             tcg_gen_qemu_ld32s(dat_l, source1_l, ctx->mem_idx);
             tcg_gen_brcond_tl(TCG_COND_GT, dat_l, source2_l, j);
             tcg_gen_qemu_st32(source2_l, source1_l, ctx->mem_idx);
             tcg_gen_br(done);
-            // here we store the thing on the left
+            /* here we store the thing on the left */
             gen_set_label(j);
             tcg_gen_qemu_st32(dat_l, source1_l, ctx->mem_idx);
-            //done
+            /*done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, dat_l);
             tcg_temp_free(source1_l);
@@ -983,18 +1009,18 @@ inline static void gen_atomic(DisasContext *ctx, uint32_t opc,
             source1_l = tcg_temp_local_new();
             source2_l = tcg_temp_local_new();
             dat_l = tcg_temp_local_new();
-            TCGLabel* j = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *j = gen_new_label();
+            TCGLabel *done = gen_new_label();
             tcg_gen_mov_tl(source1_l, source1);
             tcg_gen_ext32u_tl(source2_l, source2);
             tcg_gen_qemu_ld32u(dat_l, source1_l, ctx->mem_idx);
             tcg_gen_brcond_tl(TCG_COND_LTU, dat_l, source2_l, j);
             tcg_gen_qemu_st32(source2_l, source1_l, ctx->mem_idx);
             tcg_gen_br(done);
-            // here we store the thing on the left
+            /* here we store the thing on the left */
             gen_set_label(j);
             tcg_gen_qemu_st32(dat_l, source1_l, ctx->mem_idx);
-            //done
+            /*done */
             gen_set_label(done);
             tcg_gen_ext32s_tl(source1, dat_l);
             tcg_temp_free(source1_l);
@@ -1008,18 +1034,18 @@ inline static void gen_atomic(DisasContext *ctx, uint32_t opc,
             source1_l = tcg_temp_local_new();
             source2_l = tcg_temp_local_new();
             dat_l = tcg_temp_local_new();
-            TCGLabel* j = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *j = gen_new_label();
+            TCGLabel *done = gen_new_label();
             tcg_gen_mov_tl(source1_l, source1);
             tcg_gen_ext32u_tl(source2_l, source2);
             tcg_gen_qemu_ld32u(dat_l, source1_l, ctx->mem_idx);
             tcg_gen_brcond_tl(TCG_COND_GTU, dat_l, source2_l, j);
             tcg_gen_qemu_st32(source2_l, source1_l, ctx->mem_idx);
             tcg_gen_br(done);
-            // here we store the thing on the left
+            /* here we store the thing on the left */
             gen_set_label(j);
             tcg_gen_qemu_st32(dat_l, source1_l, ctx->mem_idx);
-            //done
+            /*done */
             gen_set_label(done);
             tcg_gen_ext32s_tl(source1, dat_l);
             tcg_temp_free(source1_l);
@@ -1029,19 +1055,19 @@ inline static void gen_atomic(DisasContext *ctx, uint32_t opc,
         break;
 #if defined(TARGET_RISCV64)
     case OPC_RISC_LR_D:
-        // put addr in load_reservation
+        /* put addr in load_reservation */
         tcg_gen_mov_tl(load_reservation, source1);
         tcg_gen_qemu_ld64(source1, source1, ctx->mem_idx);
         break;
     case OPC_RISC_SC_D: {
-        TCGLabel* fail = gen_new_label();
-        TCGLabel* done = gen_new_label();
+        TCGLabel *fail = gen_new_label();
+        TCGLabel *done = gen_new_label();
         tcg_gen_brcond_tl(TCG_COND_NE, load_reservation, source1, fail);
         tcg_gen_qemu_st64(source2, source1, ctx->mem_idx);
-        tcg_gen_movi_tl(source1, 0); //success
+        tcg_gen_movi_tl(source1, 0); /*success */
         tcg_gen_br(done);
         gen_set_label(fail);
-        tcg_gen_movi_tl(source1, 1); //fail
+        tcg_gen_movi_tl(source1, 1); /*fail */
         gen_set_label(done);
         break;
         }
@@ -1080,18 +1106,18 @@ inline static void gen_atomic(DisasContext *ctx, uint32_t opc,
             source1_l = tcg_temp_local_new();
             source2_l = tcg_temp_local_new();
             dat_l = tcg_temp_local_new();
-            TCGLabel* j = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *j = gen_new_label();
+            TCGLabel *done = gen_new_label();
             tcg_gen_mov_tl(source1_l, source1);
             tcg_gen_mov_tl(source2_l, source2);
             tcg_gen_qemu_ld64(dat_l, source1_l, ctx->mem_idx);
             tcg_gen_brcond_tl(TCG_COND_LT, dat_l, source2_l, j);
             tcg_gen_qemu_st64(source2_l, source1_l, ctx->mem_idx);
             tcg_gen_br(done);
-            // here we store the thing on the left
+            /* here we store the thing on the left */
             gen_set_label(j);
             tcg_gen_qemu_st64(dat_l, source1_l, ctx->mem_idx);
-            //done
+            /*done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, dat_l);
             tcg_temp_free(source1_l);
@@ -1105,18 +1131,18 @@ inline static void gen_atomic(DisasContext *ctx, uint32_t opc,
             source1_l = tcg_temp_local_new();
             source2_l = tcg_temp_local_new();
             dat_l = tcg_temp_local_new();
-            TCGLabel* j = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *j = gen_new_label();
+            TCGLabel *done = gen_new_label();
             tcg_gen_mov_tl(source1_l, source1);
             tcg_gen_mov_tl(source2_l, source2);
             tcg_gen_qemu_ld64(dat_l, source1_l, ctx->mem_idx);
             tcg_gen_brcond_tl(TCG_COND_GT, dat_l, source2_l, j);
             tcg_gen_qemu_st64(source2_l, source1_l, ctx->mem_idx);
             tcg_gen_br(done);
-            // here we store the thing on the left
+            /* here we store the thing on the left */
             gen_set_label(j);
             tcg_gen_qemu_st64(dat_l, source1_l, ctx->mem_idx);
-            //done
+            /*done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, dat_l);
             tcg_temp_free(source1_l);
@@ -1130,18 +1156,18 @@ inline static void gen_atomic(DisasContext *ctx, uint32_t opc,
             source1_l = tcg_temp_local_new();
             source2_l = tcg_temp_local_new();
             dat_l = tcg_temp_local_new();
-            TCGLabel* j = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *j = gen_new_label();
+            TCGLabel *done = gen_new_label();
             tcg_gen_mov_tl(source1_l, source1);
             tcg_gen_mov_tl(source2_l, source2);
             tcg_gen_qemu_ld64(dat_l, source1_l, ctx->mem_idx);
             tcg_gen_brcond_tl(TCG_COND_LTU, dat_l, source2_l, j);
             tcg_gen_qemu_st64(source2_l, source1_l, ctx->mem_idx);
             tcg_gen_br(done);
-            // here we store the thing on the left
+            /* here we store the thing on the left */
             gen_set_label(j);
             tcg_gen_qemu_st64(dat_l, source1_l, ctx->mem_idx);
-            //done
+            /*done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, dat_l);
             tcg_temp_free(source1_l);
@@ -1155,18 +1181,18 @@ inline static void gen_atomic(DisasContext *ctx, uint32_t opc,
             source1_l = tcg_temp_local_new();
             source2_l = tcg_temp_local_new();
             dat_l = tcg_temp_local_new();
-            TCGLabel* j = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *j = gen_new_label();
+            TCGLabel *done = gen_new_label();
             tcg_gen_mov_tl(source1_l, source1);
             tcg_gen_mov_tl(source2_l, source2);
             tcg_gen_qemu_ld64(dat_l, source1_l, ctx->mem_idx);
             tcg_gen_brcond_tl(TCG_COND_GTU, dat_l, source2_l, j);
             tcg_gen_qemu_st64(source2_l, source1_l, ctx->mem_idx);
             tcg_gen_br(done);
-            // here we store the thing on the left
+            /* here we store the thing on the left */
             gen_set_label(j);
             tcg_gen_qemu_st64(dat_l, source1_l, ctx->mem_idx);
-            //done
+            /*done */
             gen_set_label(done);
             tcg_gen_mov_tl(source1, dat_l);
             tcg_temp_free(source1_l);
@@ -1181,17 +1207,17 @@ inline static void gen_atomic(DisasContext *ctx, uint32_t opc,
 
     }
 
-    // set and free
+    /* set and free */
     gen_set_gpr(rd, source1);
     tcg_temp_free(source1);
     tcg_temp_free(source2);
     tcg_temp_free(dat);
 }
 
-inline static void gen_system(DisasContext *ctx, uint32_t opc,
+static inline void gen_system(DisasContext *ctx, uint32_t opc,
                       int rd, int rs1, int csr)
 {
-    // get index into csr array
+    /* get index into csr array */
     int backup_csr = csr;
 
     TCGv source1, csr_store, dest, rs1_pass;
@@ -1201,83 +1227,83 @@ inline static void gen_system(DisasContext *ctx, uint32_t opc,
     rs1_pass = tcg_temp_new();
     gen_get_gpr(source1, rs1);
     tcg_gen_movi_tl(rs1_pass, rs1);
-    tcg_gen_movi_tl(csr_store, csr); // copy into temp reg to feed to helper
+    tcg_gen_movi_tl(csr_store, csr); /* copy into temp reg to feed to helper */
 
     switch (opc) {
 
     case OPC_RISC_ECALL:
         switch (backup_csr) {
-            case 0x0: // ECALL
-                // always generates U-level ECALL, fixed in do_interrupt handler
-                generate_exception(ctx, RISCV_EXCP_U_ECALL);
-                tcg_gen_exit_tb(0); // no chaining
-                ctx->bstate = BS_BRANCH;
-                break;
-            case 0x1: // EBREAK
-                generate_exception(ctx, RISCV_EXCP_BREAKPOINT);
-                tcg_gen_exit_tb(0); // no chaining
-                ctx->bstate = BS_BRANCH;
-                break;
-            case 0x002: // URET
-                printf("URET unimplemented\n");
-                exit(1);
-                break;
-            case 0x102: // SRET
-                tcg_gen_movi_tl(cpu_PC, ctx->pc);
-                gen_helper_sret(cpu_PC, cpu_env, cpu_PC);
-                tcg_gen_exit_tb(0); // no chaining
-                ctx->bstate = BS_BRANCH;
-                break;
-            case 0x202: // HRET
-                printf("HRET unimplemented\n");
-                exit(1);
-                break;
-            case 0x302: // MRET
-                tcg_gen_movi_tl(cpu_PC, ctx->pc);
-                gen_helper_mret(cpu_PC, cpu_env, cpu_PC);
-                tcg_gen_exit_tb(0); // no chaining
-                ctx->bstate = BS_BRANCH;
-                break;
-            case 0x7b2: // DRET
-                printf("DRET unimplemented\n");
-                exit(1);
-                break;
-            case 0x105: // WFI
-                // nop for now, as in spike
-                break;
-            case 0x104: // SFENCE.VM
-                gen_helper_tlb_flush(cpu_env);
-                break;
-            default:
-                kill_unknown(ctx, RISCV_EXCP_ILLEGAL_INST);
-                break;
+        case 0x0: /* ECALL */
+            /* always generates U-level ECALL, fixed in do_interrupt handler */
+            generate_exception(ctx, RISCV_EXCP_U_ECALL);
+            tcg_gen_exit_tb(0); /* no chaining */
+            ctx->bstate = BS_BRANCH;
+            break;
+        case 0x1: /* EBREAK */
+            generate_exception(ctx, RISCV_EXCP_BREAKPOINT);
+            tcg_gen_exit_tb(0); /* no chaining */
+            ctx->bstate = BS_BRANCH;
+            break;
+        case 0x002: /* URET */
+            printf("URET unimplemented\n");
+            exit(1);
+            break;
+        case 0x102: /* SRET */
+            tcg_gen_movi_tl(cpu_PC, ctx->pc);
+            gen_helper_sret(cpu_PC, cpu_env, cpu_PC);
+            tcg_gen_exit_tb(0); /* no chaining */
+            ctx->bstate = BS_BRANCH;
+            break;
+        case 0x202: /* HRET */
+            printf("HRET unimplemented\n");
+            exit(1);
+            break;
+        case 0x302: /* MRET */
+            tcg_gen_movi_tl(cpu_PC, ctx->pc);
+            gen_helper_mret(cpu_PC, cpu_env, cpu_PC);
+            tcg_gen_exit_tb(0); /* no chaining */
+            ctx->bstate = BS_BRANCH;
+            break;
+        case 0x7b2: /* DRET */
+            printf("DRET unimplemented\n");
+            exit(1);
+            break;
+        case 0x105: /* WFI */
+            /* nop for now, as in spike */
+            break;
+        case 0x104: /* SFENCE.VM */
+            gen_helper_tlb_flush(cpu_env);
+            break;
+        default:
+            kill_unknown(ctx, RISCV_EXCP_ILLEGAL_INST);
+            break;
         }
         break;
     case OPC_RISC_CSRRW:
         tcg_gen_movi_tl(cpu_PC, ctx->pc);
         gen_helper_csrrw(dest, cpu_env, source1, csr_store, cpu_PC);
         gen_set_gpr(rd, dest);
-        // TODO needed? end tb since we may be changing priv modes
+        /* TODO needed? end tb since we may be changing priv modes */
         tcg_gen_movi_tl(cpu_PC, ctx->pc + 4);
-        tcg_gen_exit_tb(0); // no chaining
+        tcg_gen_exit_tb(0); /* no chaining */
         ctx->bstate = BS_BRANCH;
         break;
     case OPC_RISC_CSRRS:
         tcg_gen_movi_tl(cpu_PC, ctx->pc);
         gen_helper_csrrs(dest, cpu_env, source1, csr_store, cpu_PC, rs1_pass);
         gen_set_gpr(rd, dest);
-        // end tb since we may be changing priv modes
+        /* end tb since we may be changing priv modes */
         tcg_gen_movi_tl(cpu_PC, ctx->pc + 4);
-        tcg_gen_exit_tb(0); // no chaining
+        tcg_gen_exit_tb(0); /* no chaining */
         ctx->bstate = BS_BRANCH;
         break;
     case OPC_RISC_CSRRC:
         tcg_gen_movi_tl(cpu_PC, ctx->pc);
         gen_helper_csrrc(dest, cpu_env, source1, csr_store, cpu_PC, rs1_pass);
         gen_set_gpr(rd, dest);
-        // end tb since we may be changing priv modes
+        /* end tb since we may be changing priv modes */
         tcg_gen_movi_tl(cpu_PC, ctx->pc + 4);
-        tcg_gen_exit_tb(0); // no chaining
+        tcg_gen_exit_tb(0); /* no chaining */
         ctx->bstate = BS_BRANCH;
         break;
     case OPC_RISC_CSRRWI:
@@ -1288,9 +1314,9 @@ inline static void gen_system(DisasContext *ctx, uint32_t opc,
             gen_helper_csrrw(dest, cpu_env, imm_rs1, csr_store, cpu_PC);
             gen_set_gpr(rd, dest);
             tcg_temp_free(imm_rs1);
-            // end tb since we may be changing priv modes
+            /* end tb since we may be changing priv modes */
             tcg_gen_movi_tl(cpu_PC, ctx->pc + 4);
-            tcg_gen_exit_tb(0); // no chaining
+            tcg_gen_exit_tb(0); /* no chaining */
             ctx->bstate = BS_BRANCH;
         }
         break;
@@ -1299,12 +1325,13 @@ inline static void gen_system(DisasContext *ctx, uint32_t opc,
             tcg_gen_movi_tl(cpu_PC, ctx->pc);
             TCGv imm_rs1 = tcg_temp_new();
             tcg_gen_movi_tl(imm_rs1, rs1);
-            gen_helper_csrrs(dest, cpu_env, imm_rs1, csr_store, cpu_PC, rs1_pass);
+            gen_helper_csrrs(dest, cpu_env, imm_rs1, csr_store, cpu_PC,
+                             rs1_pass);
             gen_set_gpr(rd, dest);
             tcg_temp_free(imm_rs1);
-            // end tb since we may be changing priv modes
+            /* end tb since we may be changing priv modes */
             tcg_gen_movi_tl(cpu_PC, ctx->pc + 4);
-            tcg_gen_exit_tb(0); // no chaining
+            tcg_gen_exit_tb(0); /* no chaining */
             ctx->bstate = BS_BRANCH;
         }
         break;
@@ -1313,12 +1340,13 @@ inline static void gen_system(DisasContext *ctx, uint32_t opc,
             tcg_gen_movi_tl(cpu_PC, ctx->pc);
             TCGv imm_rs1 = tcg_temp_new();
             tcg_gen_movi_tl(imm_rs1, rs1);
-            gen_helper_csrrc(dest, cpu_env, imm_rs1, csr_store, cpu_PC, rs1_pass);
+            gen_helper_csrrc(dest, cpu_env, imm_rs1, csr_store, cpu_PC,
+                             rs1_pass);
             gen_set_gpr(rd, dest);
             tcg_temp_free(imm_rs1);
-            // end tb since we may be changing priv modes
+            /* end tb since we may be changing priv modes */
             tcg_gen_movi_tl(cpu_PC, ctx->pc + 4);
-            tcg_gen_exit_tb(0); // no chaining
+            tcg_gen_exit_tb(0); /* no chaining */
             ctx->bstate = BS_BRANCH;
         }
         break;
@@ -1335,7 +1363,7 @@ inline static void gen_system(DisasContext *ctx, uint32_t opc,
 }
 
 
-inline static void gen_fp_load(DisasContext *ctx, uint32_t opc,
+static inline void gen_fp_load(DisasContext *ctx, uint32_t opc,
                       int rd, int rs1, int16_t imm)
 {
     target_long uimm = (target_long)imm; /* sign ext 16->64 bits */
@@ -1365,7 +1393,7 @@ inline static void gen_fp_load(DisasContext *ctx, uint32_t opc,
     tcg_temp_free(t0);
 }
 
-inline static void gen_fp_store(DisasContext *ctx, uint32_t opc,
+static inline void gen_fp_store(DisasContext *ctx, uint32_t opc,
                       int rs1, int rs2, int16_t imm)
 {
     target_long uimm = (target_long)imm; /* sign ext 16->64 bits */
@@ -1398,19 +1426,20 @@ inline static void gen_fp_store(DisasContext *ctx, uint32_t opc,
     tcg_temp_free(t1);
 }
 
-inline static void gen_fp_fmadd(DisasContext *ctx, uint32_t opc,
+static inline void gen_fp_fmadd(DisasContext *ctx, uint32_t opc,
                     int rd, int rs1, int rs2, int rs3, int rm)
 {
     TCGv_i64 rm_reg = tcg_temp_new_i64();
     tcg_gen_movi_i64(rm_reg, rm);
 
     switch (opc) {
-
     case OPC_RISC_FMADD_S:
-        gen_helper_fmadd_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], cpu_fpr[rs3], rm_reg);
+        gen_helper_fmadd_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                           cpu_fpr[rs3], rm_reg);
         break;
     case OPC_RISC_FMADD_D:
-        gen_helper_fmadd_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], cpu_fpr[rs3], rm_reg);
+        gen_helper_fmadd_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                           cpu_fpr[rs3], rm_reg);
         break;
     default:
         kill_unknown(ctx, RISCV_EXCP_ILLEGAL_INST);
@@ -1420,7 +1449,7 @@ inline static void gen_fp_fmadd(DisasContext *ctx, uint32_t opc,
 
 }
 
-inline static void gen_fp_fmsub(DisasContext *ctx, uint32_t opc,
+static inline void gen_fp_fmsub(DisasContext *ctx, uint32_t opc,
                     int rd, int rs1, int rs2, int rs3, int rm)
 {
     TCGv_i64 rm_reg = tcg_temp_new_i64();
@@ -1429,10 +1458,12 @@ inline static void gen_fp_fmsub(DisasContext *ctx, uint32_t opc,
     switch (opc) {
 
     case OPC_RISC_FMSUB_S:
-        gen_helper_fmsub_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], cpu_fpr[rs3], rm_reg);
+        gen_helper_fmsub_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                           cpu_fpr[rs3], rm_reg);
         break;
     case OPC_RISC_FMSUB_D:
-        gen_helper_fmsub_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], cpu_fpr[rs3], rm_reg);
+        gen_helper_fmsub_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                           cpu_fpr[rs3], rm_reg);
         break;
     default:
         kill_unknown(ctx, RISCV_EXCP_ILLEGAL_INST);
@@ -1441,7 +1472,7 @@ inline static void gen_fp_fmsub(DisasContext *ctx, uint32_t opc,
     tcg_temp_free_i64(rm_reg);
 }
 
-inline static void gen_fp_fnmsub(DisasContext *ctx, uint32_t opc,
+static inline void gen_fp_fnmsub(DisasContext *ctx, uint32_t opc,
                     int rd, int rs1, int rs2, int rs3, int rm)
 {
     TCGv_i64 rm_reg = tcg_temp_new_i64();
@@ -1450,10 +1481,12 @@ inline static void gen_fp_fnmsub(DisasContext *ctx, uint32_t opc,
     switch (opc) {
 
     case OPC_RISC_FNMSUB_S:
-        gen_helper_fnmsub_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], cpu_fpr[rs3], rm_reg);
+        gen_helper_fnmsub_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                            cpu_fpr[rs3], rm_reg);
         break;
     case OPC_RISC_FNMSUB_D:
-        gen_helper_fnmsub_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], cpu_fpr[rs3], rm_reg);
+        gen_helper_fnmsub_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                            cpu_fpr[rs3], rm_reg);
         break;
     default:
         kill_unknown(ctx, RISCV_EXCP_ILLEGAL_INST);
@@ -1462,7 +1495,7 @@ inline static void gen_fp_fnmsub(DisasContext *ctx, uint32_t opc,
     tcg_temp_free_i64(rm_reg);
 }
 
-inline static void gen_fp_fnmadd(DisasContext *ctx, uint32_t opc,
+static inline void gen_fp_fnmadd(DisasContext *ctx, uint32_t opc,
                     int rd, int rs1, int rs2, int rs3, int rm)
 {
     TCGv_i64 rm_reg = tcg_temp_new_i64();
@@ -1471,10 +1504,12 @@ inline static void gen_fp_fnmadd(DisasContext *ctx, uint32_t opc,
     switch (opc) {
 
     case OPC_RISC_FNMADD_S:
-        gen_helper_fnmadd_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], cpu_fpr[rs3], rm_reg);
+        gen_helper_fnmadd_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                            cpu_fpr[rs3], rm_reg);
         break;
     case OPC_RISC_FNMADD_D:
-        gen_helper_fnmadd_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], cpu_fpr[rs3], rm_reg);
+        gen_helper_fnmadd_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                            cpu_fpr[rs3], rm_reg);
         break;
     default:
         kill_unknown(ctx, RISCV_EXCP_ILLEGAL_INST);
@@ -1483,7 +1518,7 @@ inline static void gen_fp_fnmadd(DisasContext *ctx, uint32_t opc,
     tcg_temp_free_i64(rm_reg);
 }
 
-inline static void gen_fp_arith(DisasContext *ctx, uint32_t opc,
+static inline void gen_fp_arith(DisasContext *ctx, uint32_t opc,
                     int rd, int rs1, int rs2, int rm)
 {
     TCGv_i64 rm_reg = tcg_temp_new_i64();
@@ -1492,31 +1527,38 @@ inline static void gen_fp_arith(DisasContext *ctx, uint32_t opc,
 
     switch (opc) {
     case OPC_RISC_FADD_S:
-        gen_helper_fadd_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], rm_reg);
+        gen_helper_fadd_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                          rm_reg);
         break;
     case OPC_RISC_FSUB_S:
-        gen_helper_fsub_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], rm_reg);
+        gen_helper_fsub_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                          rm_reg);
         break;
     case OPC_RISC_FMUL_S:
-        gen_helper_fmul_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], rm_reg);
+        gen_helper_fmul_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                          rm_reg);
         break;
     case OPC_RISC_FDIV_S:
-        gen_helper_fdiv_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], rm_reg);
+        gen_helper_fdiv_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                          rm_reg);
         break;
     case OPC_RISC_FSGNJ_S:
-        // also handles: OPC_RISC_FSGNJN_S, OPC_RISC_FSGNJX_S
+        /* also handles: OPC_RISC_FSGNJN_S, OPC_RISC_FSGNJX_S */
         if (rm == 0x0) {
-            gen_helper_fsgnj_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2]);
+            gen_helper_fsgnj_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1],
+                               cpu_fpr[rs2]);
         } else if (rm == 0x1) {
-            gen_helper_fsgnjn_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2]);
+            gen_helper_fsgnjn_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1],
+                                cpu_fpr[rs2]);
         } else if (rm == 0x2) {
-            gen_helper_fsgnjx_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2]);
+            gen_helper_fsgnjx_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1],
+                                cpu_fpr[rs2]);
         } else {
             kill_unknown(ctx, RISCV_EXCP_ILLEGAL_INST);
         }
         break;
     case OPC_RISC_FMIN_S:
-        // also handles: OPC_RISC_FMAX_S
+        /* also handles: OPC_RISC_FMAX_S */
         if (rm == 0x0) {
             gen_helper_fmin_s(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2]);
         } else if (rm == 0x1) {
@@ -1531,7 +1573,7 @@ inline static void gen_fp_arith(DisasContext *ctx, uint32_t opc,
         break;
 
     case OPC_RISC_FEQ_S:
-        // also handles: OPC_RISC_FLT_S, OPC_RISC_FLE_S
+        /* also handles: OPC_RISC_FLT_S, OPC_RISC_FLE_S */
         if (rm == 0x0) {
             gen_helper_fle_s(write_int_rd, cpu_env, cpu_fpr[rs1], cpu_fpr[rs2]);
         } else if (rm == 0x1) {
@@ -1545,18 +1587,18 @@ inline static void gen_fp_arith(DisasContext *ctx, uint32_t opc,
         break;
 
     case OPC_RISC_FCVT_W_S:
-        // also OPC_RISC_FCVT_WU_S, OPC_RISC_FCVT_L_S, OPC_RISC_FCVT_LU_S
-        if (rs2 == 0x0) { // FCVT_W_S
+        /* also OPC_RISC_FCVT_WU_S, OPC_RISC_FCVT_L_S, OPC_RISC_FCVT_LU_S */
+        if (rs2 == 0x0) { /* FCVT_W_S */
             gen_helper_fcvt_w_s(write_int_rd, cpu_env, cpu_fpr[rs1], rm_reg);
-        } else if (rs2 == 0x1) { // FCVT_WU_S
+        } else if (rs2 == 0x1) { /* FCVT_WU_S */
             gen_helper_fcvt_wu_s(write_int_rd, cpu_env, cpu_fpr[rs1], rm_reg);
-        } else if (rs2 == 0x2) { // FCVT_L_S
+        } else if (rs2 == 0x2) { /* FCVT_L_S */
 #if defined(TARGET_RISCV64)
             gen_helper_fcvt_l_s(write_int_rd, cpu_env, cpu_fpr[rs1], rm_reg);
 #else
             kill_unknown(ctx, RISCV_EXCP_ILLEGAL_INST);
 #endif
-        } else if (rs2 == 0x3) { // FCVT_LU_S
+        } else if (rs2 == 0x3) { /* FCVT_LU_S */
 #if defined(TARGET_RISCV64)
             gen_helper_fcvt_lu_s(write_int_rd, cpu_env, cpu_fpr[rs1], rm_reg);
 #else
@@ -1569,19 +1611,19 @@ inline static void gen_fp_arith(DisasContext *ctx, uint32_t opc,
         break;
 
     case OPC_RISC_FCVT_S_W:
-        // also OPC_RISC_FCVT_S_WU, OPC_RISC_FCVT_S_L, OPC_RISC_FCVT_S_LU
+        /* also OPC_RISC_FCVT_S_WU, OPC_RISC_FCVT_S_L, OPC_RISC_FCVT_S_LU */
         gen_get_gpr(write_int_rd, rs1);
-        if (rs2 == 0) { // FCVT_S_W
+        if (rs2 == 0) { /* FCVT_S_W */
             gen_helper_fcvt_s_w(cpu_fpr[rd], cpu_env, write_int_rd, rm_reg);
-        } else if (rs2 == 0x1) { // FCVT_S_WU
+        } else if (rs2 == 0x1) { /* FCVT_S_WU */
             gen_helper_fcvt_s_wu(cpu_fpr[rd], cpu_env, write_int_rd, rm_reg);
-        } else if (rs2 == 0x2) { // FCVT_S_L
+        } else if (rs2 == 0x2) { /* FCVT_S_L */
 #if defined(TARGET_RISCV64)
             gen_helper_fcvt_s_l(cpu_fpr[rd], cpu_env, write_int_rd, rm_reg);
 #else
             kill_unknown(ctx, RISCV_EXCP_ILLEGAL_INST);
 #endif
-        } else if (rs2 == 0x3) { // FCVT_S_LU
+        } else if (rs2 == 0x3) { /* FCVT_S_LU */
 #if defined(TARGET_RISCV64)
             gen_helper_fcvt_s_lu(cpu_fpr[rd], cpu_env, write_int_rd, rm_reg);
 #else
@@ -1593,8 +1635,8 @@ inline static void gen_fp_arith(DisasContext *ctx, uint32_t opc,
         break;
 
     case OPC_RISC_FMV_X_S:
-        // also OPC_RISC_FCLASS_S
-        if (rm == 0x0) { // FMV
+        /* also OPC_RISC_FCLASS_S */
+        if (rm == 0x0) { /* FMV */
 #if defined(TARGET_RISCV64)
             tcg_gen_ext32s_tl(write_int_rd, cpu_fpr[rs1]);
 #else
@@ -1617,33 +1659,40 @@ inline static void gen_fp_arith(DisasContext *ctx, uint32_t opc,
 #endif
         break;
 
-    // double
+    /* double */
     case OPC_RISC_FADD_D:
-        gen_helper_fadd_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], rm_reg);
+        gen_helper_fadd_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                          rm_reg);
         break;
     case OPC_RISC_FSUB_D:
-        gen_helper_fsub_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], rm_reg);
+        gen_helper_fsub_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                          rm_reg);
         break;
     case OPC_RISC_FMUL_D:
-        gen_helper_fmul_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], rm_reg);
+        gen_helper_fmul_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                          rm_reg);
         break;
     case OPC_RISC_FDIV_D:
-        gen_helper_fdiv_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2], rm_reg);
+        gen_helper_fdiv_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2],
+                          rm_reg);
         break;
     case OPC_RISC_FSGNJ_D:
-        // also OPC_RISC_FSGNJN_D, OPC_RISC_FSGNJX_D
+        /* also OPC_RISC_FSGNJN_D, OPC_RISC_FSGNJX_D */
         if (rm == 0x0) {
-            gen_helper_fsgnj_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2]);
+            gen_helper_fsgnj_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1],
+                               cpu_fpr[rs2]);
         } else if (rm == 0x1) {
-            gen_helper_fsgnjn_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2]);
+            gen_helper_fsgnjn_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1],
+                                cpu_fpr[rs2]);
         } else if (rm == 0x2) {
-            gen_helper_fsgnjx_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2]);
+            gen_helper_fsgnjx_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1],
+                                cpu_fpr[rs2]);
         } else {
             kill_unknown(ctx, RISCV_EXCP_ILLEGAL_INST);
         }
         break;
     case OPC_RISC_FMIN_D:
-        // also OPC_RISC_FMAX_D
+        /* also OPC_RISC_FMAX_D */
         if (rm == 0x0) {
             gen_helper_fmin_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], cpu_fpr[rs2]);
         } else if (rm == 0x1) {
@@ -1670,7 +1719,7 @@ inline static void gen_fp_arith(DisasContext *ctx, uint32_t opc,
         gen_helper_fsqrt_d(cpu_fpr[rd], cpu_env, cpu_fpr[rs1], rm_reg);
         break;
     case OPC_RISC_FEQ_D:
-        // also OPC_RISC_FLT_D, OPC_RISC_FLE_D
+        /* also OPC_RISC_FLT_D, OPC_RISC_FLE_D */
         if (rm == 0x0) {
             gen_helper_fle_d(write_int_rd, cpu_env, cpu_fpr[rs1], cpu_fpr[rs2]);
         } else if (rm == 0x1) {
@@ -1683,7 +1732,7 @@ inline static void gen_fp_arith(DisasContext *ctx, uint32_t opc,
         gen_set_gpr(rd, write_int_rd);
         break;
     case OPC_RISC_FCVT_W_D:
-        // also OPC_RISC_FCVT_WU_D, OPC_RISC_FCVT_L_D, OPC_RISC_FCVT_LU_D
+        /* also OPC_RISC_FCVT_WU_D, OPC_RISC_FCVT_L_D, OPC_RISC_FCVT_LU_D */
         if (rs2 == 0x0) {
             gen_helper_fcvt_w_d(write_int_rd, cpu_env, cpu_fpr[rs1], rm_reg);
         } else if (rs2 == 0x1) {
@@ -1706,7 +1755,7 @@ inline static void gen_fp_arith(DisasContext *ctx, uint32_t opc,
         gen_set_gpr(rd, write_int_rd);
         break;
     case OPC_RISC_FCVT_D_W:
-        // also OPC_RISC_FCVT_D_WU, OPC_RISC_FCVT_D_L, OPC_RISC_FCVT_D_LU
+        /* also OPC_RISC_FCVT_D_WU, OPC_RISC_FCVT_D_L, OPC_RISC_FCVT_D_LU */
         gen_get_gpr(write_int_rd, rs1);
         if (rs2 == 0x0) {
             gen_helper_fcvt_d_w(cpu_fpr[rd], cpu_env, write_int_rd, rm_reg);
@@ -1730,8 +1779,8 @@ inline static void gen_fp_arith(DisasContext *ctx, uint32_t opc,
         break;
 #if defined(TARGET_RISCV64)
     case OPC_RISC_FMV_X_D:
-        // also OPC_RISC_FCLASS_D
-        if (rm == 0x0) { // FMV
+        /* also OPC_RISC_FCLASS_D */
+        if (rm == 0x0) { /* FMV */
             tcg_gen_mov_tl(write_int_rd, cpu_fpr[rs1]);
         } else if (rm == 0x1) {
             gen_helper_fclass_d(write_int_rd, cpu_env, cpu_fpr[rs1]);
@@ -1753,7 +1802,7 @@ inline static void gen_fp_arith(DisasContext *ctx, uint32_t opc,
     tcg_temp_free(write_int_rd);
 }
 
-static void decode_opc (CPURISCVState *env, DisasContext *ctx)
+static void decode_opc(CPURISCVState *env, DisasContext *ctx)
 {
 
     int rs1;
@@ -1763,21 +1812,22 @@ static void decode_opc (CPURISCVState *env, DisasContext *ctx)
     int16_t imm;
     target_long ubimm;
 
-    // do not do misaligned address check here, address should never be
-    // misaligned
-    //
-    // instead, all control flow instructions check for themselves
-    //
-    // this is because epc must be the address of the control flow instruction
-    // that "caused" to the misaligned instruction access
-    //
-    // we leave this check here for now, since not all control flow
-    // instructions have been updated yet
+    /* do not do misaligned address check here, address should never be
+     * misaligned
+     *
+     * instead, all control flow instructions check for themselves
+     *
+     * this is because epc must be the address of the control flow instruction
+     * that "caused" to the misaligned instruction access
+     *
+     * we leave this check here for now, since not all control flow
+     * instructions have been updated yet */
 
     /* make sure instructions are on a word boundary */
     if (unlikely(ctx->pc & 0x3)) {
         printf("addr misaligned\n");
-        printf("misaligned instruction, not completely implemented for riscv\n");
+        printf("misaligned instruction, not completely implemented for riscv\
+                \n");
         exit(1);
         return;
     }
@@ -1789,8 +1839,8 @@ static void decode_opc (CPURISCVState *env, DisasContext *ctx)
     imm = (int16_t)(((int32_t)ctx->opcode) >> 20); /* sign extends */
 
     #ifdef RISCV_DEBUG_PRINT
-    // this will print a log similar to spike, should be left off unless
-    // you're debugging QEMU
+    /* this will print a log similar to spike, should be left off unless */
+    /* you're debugging QEMU */
     TCGv print_helper_tmp = tcg_temp_local_new();
     TCGv printpc = tcg_temp_local_new();
     tcg_gen_movi_tl(print_helper_tmp, ctx->opcode);
@@ -1804,14 +1854,14 @@ static void decode_opc (CPURISCVState *env, DisasContext *ctx)
 
     case OPC_RISC_LUI:
         if (rd == 0) {
-            break; // NOP
+            break; /* NOP */
         }
         tcg_gen_movi_tl(cpu_gpr[rd], (ctx->opcode & 0xFFFFF000));
         tcg_gen_ext32s_tl(cpu_gpr[rd], cpu_gpr[rd]);
         break;
     case OPC_RISC_AUIPC:
         if (rd == 0) {
-            break; // NOP
+            break; /* NOP */
         }
         tcg_gen_movi_tl(cpu_gpr[rd], (ctx->opcode & 0xFFFFF000));
         tcg_gen_ext32s_tl(cpu_gpr[rd], cpu_gpr[rd]);
@@ -1820,11 +1870,11 @@ static void decode_opc (CPURISCVState *env, DisasContext *ctx)
     case OPC_RISC_JAL: {
             TCGv nextpc = tcg_temp_local_new();
             TCGv testpc = tcg_temp_local_new();
-            TCGLabel* misaligned = gen_new_label();
-            TCGLabel* done = gen_new_label();
+            TCGLabel *misaligned = gen_new_label();
+            TCGLabel *done = gen_new_label();
             ubimm = (target_long) (GET_JAL_IMM(ctx->opcode));
             tcg_gen_movi_tl(nextpc, ctx->pc + ubimm);
-            // check misaligned:
+            /* check misaligned: */
             tcg_gen_andi_tl(testpc, nextpc, 0x3);
             tcg_gen_brcondi_tl(TCG_COND_NE, testpc, 0x0, misaligned);
             if (rd != 0) {
@@ -1836,11 +1886,11 @@ static void decode_opc (CPURISCVState *env, DisasContext *ctx)
             tcg_gen_movi_tl(cpu_PC, ctx->pc + ubimm);
             tcg_gen_exit_tb(0);
 #else
-            gen_goto_tb(ctx, 0, ctx->pc + ubimm); // must use this for safety
+            gen_goto_tb(ctx, 0, ctx->pc + ubimm); /* must use this for safety */
 #endif
             tcg_gen_br(done);
             gen_set_label(misaligned);
-            // throw exception for misaligned case
+            /* throw exception for misaligned case */
             generate_exception_mbadaddr(ctx, RISCV_EXCP_INST_ADDR_MIS);
             gen_set_label(done);
             ctx->bstate = BS_BRANCH;
@@ -1852,52 +1902,55 @@ static void decode_opc (CPURISCVState *env, DisasContext *ctx)
         gen_jalr(ctx, MASK_OP_JALR(ctx->opcode), rd, rs1, imm);
         break;
     case OPC_RISC_BRANCH:
-        gen_branch(ctx, MASK_OP_BRANCH(ctx->opcode), rs1, rs2, GET_B_IMM(ctx->opcode));
+        gen_branch(ctx, MASK_OP_BRANCH(ctx->opcode), rs1, rs2,
+                   GET_B_IMM(ctx->opcode));
         break;
     case OPC_RISC_LOAD:
         gen_load(ctx, MASK_OP_LOAD(ctx->opcode), rd, rs1, imm);
         break;
     case OPC_RISC_STORE:
-        gen_store(ctx, MASK_OP_STORE(ctx->opcode), rs1, rs2, GET_STORE_IMM(ctx->opcode));
+        gen_store(ctx, MASK_OP_STORE(ctx->opcode), rs1, rs2,
+                  GET_STORE_IMM(ctx->opcode));
         break;
     case OPC_RISC_ARITH_IMM:
         if (rd == 0) {
-            break; // NOP
+            break; /* NOP */
         }
         gen_arith_imm(ctx, MASK_OP_ARITH_IMM(ctx->opcode), rd, rs1, imm);
         break;
     case OPC_RISC_ARITH:
         if (rd == 0) {
-            break; // NOP
+            break; /* NOP */
         }
         gen_arith(ctx, MASK_OP_ARITH(ctx->opcode), rd, rs1, rs2);
         break;
 #if defined(TARGET_RISCV64)
     case OPC_RISC_ARITH_IMM_W:
         if (rd == 0) {
-            break; // NOP
+            break; /* NOP */
         }
         gen_arith_imm_w(ctx, MASK_OP_ARITH_IMM_W(ctx->opcode), rd, rs1, imm);
         break;
     case OPC_RISC_ARITH_W:
         if (rd == 0) {
-            break; // NOP
+            break; /* NOP */
         }
         gen_arith_w(ctx, MASK_OP_ARITH_W(ctx->opcode), rd, rs1, rs2);
         break;
 #endif
     case OPC_RISC_FENCE:
-        // standard fence is nop
-        // fence_i flushes TB (like an icache):
-        if (ctx->opcode & 0x1000) { // FENCE_I
+        /* standard fence is nop */
+        /* fence_i flushes TB (like an icache): */
+        if (ctx->opcode & 0x1000) { /* FENCE_I */
             gen_helper_fence_i(cpu_env);
             tcg_gen_movi_tl(cpu_PC, ctx->pc + 4);
-            tcg_gen_exit_tb(0); // no chaining
+            tcg_gen_exit_tb(0); /* no chaining */
             ctx->bstate = BS_BRANCH;
         }
         break;
     case OPC_RISC_SYSTEM:
-        gen_system(ctx, MASK_OP_SYSTEM(ctx->opcode), rd, rs1, (ctx->opcode & 0xFFF00000) >> 20);
+        gen_system(ctx, MASK_OP_SYSTEM(ctx->opcode), rd, rs1,
+                   (ctx->opcode & 0xFFF00000) >> 20);
         break;
     case OPC_RISC_ATOMIC:
         gen_atomic(ctx, MASK_OP_ATOMIC(ctx->opcode), rd, rs1, rs2);
@@ -1906,22 +1959,28 @@ static void decode_opc (CPURISCVState *env, DisasContext *ctx)
         gen_fp_load(ctx, MASK_OP_FP_LOAD(ctx->opcode), rd, rs1, imm);
         break;
     case OPC_RISC_FP_STORE:
-        gen_fp_store(ctx, MASK_OP_FP_STORE(ctx->opcode), rs1, rs2, GET_STORE_IMM(ctx->opcode));
+        gen_fp_store(ctx, MASK_OP_FP_STORE(ctx->opcode), rs1, rs2,
+                     GET_STORE_IMM(ctx->opcode));
         break;
     case OPC_RISC_FMADD:
-        gen_fp_fmadd(ctx, MASK_OP_FP_FMADD(ctx->opcode), rd, rs1, rs2, GET_RS3(ctx->opcode), GET_RM(ctx->opcode));
+        gen_fp_fmadd(ctx, MASK_OP_FP_FMADD(ctx->opcode), rd, rs1, rs2,
+                     GET_RS3(ctx->opcode), GET_RM(ctx->opcode));
         break;
     case OPC_RISC_FMSUB:
-        gen_fp_fmsub(ctx, MASK_OP_FP_FMSUB(ctx->opcode), rd, rs1, rs2, GET_RS3(ctx->opcode), GET_RM(ctx->opcode));
+        gen_fp_fmsub(ctx, MASK_OP_FP_FMSUB(ctx->opcode), rd, rs1, rs2,
+                     GET_RS3(ctx->opcode), GET_RM(ctx->opcode));
         break;
     case OPC_RISC_FNMSUB:
-        gen_fp_fnmsub(ctx, MASK_OP_FP_FNMSUB(ctx->opcode), rd, rs1, rs2, GET_RS3(ctx->opcode), GET_RM(ctx->opcode));
+        gen_fp_fnmsub(ctx, MASK_OP_FP_FNMSUB(ctx->opcode), rd, rs1, rs2,
+                      GET_RS3(ctx->opcode), GET_RM(ctx->opcode));
         break;
     case OPC_RISC_FNMADD:
-        gen_fp_fnmadd(ctx, MASK_OP_FP_FNMADD(ctx->opcode), rd, rs1, rs2, GET_RS3(ctx->opcode), GET_RM(ctx->opcode));
+        gen_fp_fnmadd(ctx, MASK_OP_FP_FNMADD(ctx->opcode), rd, rs1, rs2,
+                      GET_RS3(ctx->opcode), GET_RM(ctx->opcode));
         break;
     case OPC_RISC_FP_ARITH:
-        gen_fp_arith(ctx, MASK_OP_FP_ARITH(ctx->opcode), rd, rs1, rs2, GET_RM(ctx->opcode));
+        gen_fp_arith(ctx, MASK_OP_FP_ARITH(ctx->opcode), rd, rs1, rs2,
+                     GET_RM(ctx->opcode));
         break;
     default:
         kill_unknown(ctx, RISCV_EXCP_ILLEGAL_INST);
@@ -1937,21 +1996,21 @@ gen_intermediate_code_internal(CPURISCVState *env, TranslationBlock *tb,
     CPUState *cs = CPU(cpu);
     DisasContext ctx;
     target_ulong pc_start;
-    target_ulong next_page_start; // new
+    target_ulong next_page_start; /* new */
     int num_insns;
     int max_insns;
     pc_start = tb->pc;
     next_page_start = (pc_start & TARGET_PAGE_MASK) + TARGET_PAGE_SIZE;
     ctx.pc = pc_start;
 
-    // once we have GDB, the rest of the translate.c implementation should be
-    // ready for singlestep
+    /* once we have GDB, the rest of the translate.c implementation should be */
+    /* ready for singlestep */
     ctx.singlestep_enabled = cs->singlestep_enabled;
 
     ctx.tb = tb;
     ctx.bstate = BS_NONE;
 
-    // restore_cpu_state?
+    /* restore_cpu_state? */
 
     ctx.mem_idx = cpu_mmu_index(env, false);
     num_insns = 0;
@@ -2000,7 +2059,7 @@ gen_intermediate_code_internal(CPURISCVState *env, TranslationBlock *tb,
         if (num_insns >= max_insns) {
             break;
         }
-        if(singlestep) {
+        if (singlestep) {
             break;
         }
 
@@ -2010,23 +2069,26 @@ gen_intermediate_code_internal(CPURISCVState *env, TranslationBlock *tb,
     }
     if (cs->singlestep_enabled && ctx.bstate != BS_BRANCH) {
         if (ctx.bstate == BS_NONE) {
-            tcg_gen_movi_tl(cpu_PC, ctx.pc); // NOT PC+4, that was already done
+            tcg_gen_movi_tl(cpu_PC, ctx.pc); /* NOT PC+4, that was already
+                                                done */
         }
         gen_helper_raise_exception_debug(cpu_env);
     } else {
         switch (ctx.bstate) {
-            case BS_STOP:
-                gen_goto_tb(&ctx, 0, ctx.pc);
-                break;
-            case BS_NONE:
-                // DO NOT CHAIN. This is for END-OF-PAGE. See gen_goto_tb.
-                tcg_gen_movi_tl(cpu_PC, ctx.pc); // NOT PC+4, that was already done
-                tcg_gen_exit_tb(0);
-                break;
-            case BS_BRANCH:
-                // anything using BS_BRANCH will have generated it's own exit seq
-            default:
-                break;
+        case BS_STOP:
+            gen_goto_tb(&ctx, 0, ctx.pc);
+            break;
+        case BS_NONE:
+            /* DO NOT CHAIN. This is for END-OF-PAGE. See gen_goto_tb. */
+            tcg_gen_movi_tl(cpu_PC, ctx.pc); /* NOT PC+4, that was already
+                                                done */
+            tcg_gen_exit_tb(0);
+            break;
+        case BS_BRANCH:
+            /* anything using BS_BRANCH will have generated it's own exit
+               seq */
+        default:
+            break;
         }
     }
 done_generating:
@@ -2035,7 +2097,7 @@ done_generating:
     tb->icount = num_insns;
 
 /*
-#ifdef DEBUG_DISAS // TODO: riscv disassembly
+#ifdef DEBUG_DISAS  TODO: riscv disassembly
     LOG_DISAS("\n");
     if (qemu_loglevel_mask(CPU_LOG_TB_IN_ASM)) {
         qemu_log("IN: %s\n", lookup_symbol(pc_start));
@@ -2045,7 +2107,7 @@ done_generating:
 #endif*/
 }
 
-void gen_intermediate_code (CPURISCVState *env, struct TranslationBlock *tb)
+void gen_intermediate_code(CPURISCVState *env, struct TranslationBlock *tb)
 {
     gen_intermediate_code_internal(env, tb, false);
 }
@@ -2065,7 +2127,8 @@ void riscv_cpu_dump_state(CPUState *cs, FILE *f, fprintf_function cpu_fprintf,
         }
     }
 
-    cpu_fprintf(f, " %s " TARGET_FMT_lx "\n", "MSTATUS ", env->csr[CSR_MSTATUS]);
+    cpu_fprintf(f, " %s " TARGET_FMT_lx "\n", "MSTATUS ",
+                env->csr[CSR_MSTATUS]);
     cpu_fprintf(f, " %s " TARGET_FMT_lx "\n", "MIP     ", env->csr[CSR_MIP]);
 
     cpu_fprintf(f, " %s " TARGET_FMT_lx "\n", "MIE     ", env->csr[CSR_MIE]);
@@ -2093,9 +2156,9 @@ void riscv_tcg_init(void)
 
     cpu_env = tcg_global_reg_new_ptr(TCG_AREG0, "env");
 
-    // WARNING: cpu_gpr[0] is not allocated ON PURPOSE. Do not use it.
-    // Use the gen_set_gpr and gen_get_gpr helper functions when accessing
-    // registers, unless you specifically block reads/writes to reg 0
+    /* WARNING: cpu_gpr[0] is not allocated ON PURPOSE. Do not use it. */
+    /* Use the gen_set_gpr and gen_get_gpr helper functions when accessing */
+    /* registers, unless you specifically block reads/writes to reg 0 */
     TCGV_UNUSED(cpu_gpr[0]);
     for (i = 1; i < 32; i++) {
         cpu_gpr[i] = tcg_global_mem_new(cpu_env,
@@ -2112,7 +2175,7 @@ void riscv_tcg_init(void)
     cpu_PC = tcg_global_mem_new(cpu_env,
                                 offsetof(CPURISCVState, PC), "PC");
 
-    // TODO: not initialized
+    /* TODO: not initialized */
     load_reservation = tcg_global_mem_new(cpu_env,
                      offsetof(CPURISCVState, load_reservation),
                      "load_reservation");
@@ -2128,20 +2191,21 @@ RISCVCPU *cpu_riscv_init(const char *cpu_model)
     const riscv_def_t *def;
 
     def = cpu_riscv_find_by_name(cpu_model);
-    if (!def)
+    if (!def) {
         return NULL;
+    }
     cpu = RISCV_CPU(object_new(TYPE_RISCV_CPU));
     env = &cpu->env;
     env->cpu_model = def;
 
-    memset(env->csr, 0, 4096*sizeof(uint64_t));
+    memset(env->csr, 0, 4096 * sizeof(uint64_t));
     env->priv = PRV_M;
 
-    // set mcpuid from def
+    /* set mcpuid from def */
     env->csr[CSR_MISA] = def->init_misa_reg;
     object_property_set_bool(OBJECT(cpu), true, "realized", NULL);
 
-    // fpu flags:
+    /* fpu flags: */
     set_default_nan_mode(1, &env->fp_status);
 
     return cpu;
@@ -2152,7 +2216,7 @@ void cpu_state_reset(CPURISCVState *env)
     RISCVCPU *cpu = riscv_env_get_cpu(env);
     CPUState *cs = CPU(cpu);
 
-    // config string is handled in riscv_board
+    /* config string is handled in riscv_board */
 
     env->priv = PRV_M;
     env->PC = DEFAULT_RSTVEC;
@@ -2160,8 +2224,9 @@ void cpu_state_reset(CPURISCVState *env)
     cs->exception_index = EXCP_NONE;
 }
 
-// TODO what is this?
-void restore_state_to_opc(CPURISCVState *env, TranslationBlock *tb, target_ulong *data)
+/* TODO what is this? */
+void restore_state_to_opc(CPURISCVState *env, TranslationBlock *tb,
+                          target_ulong *data)
 {
     env->PC = data[0];
 }

--- a/target-riscv/translate_init.c
+++ b/target-riscv/translate_init.c
@@ -18,8 +18,8 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#define MCPUID_RV64I   (2L << (TARGET_LONG_BITS-2))
-#define MCPUID_RV32I   (1L << (TARGET_LONG_BITS-2))
+#define MCPUID_RV64I   (2L << (TARGET_LONG_BITS - 2))
+#define MCPUID_RV32I   (1L << (TARGET_LONG_BITS - 2))
 #define MCPUID_SUPER   (1L << ('S' - 'A'))
 #define MCPUID_USER    (1L << ('U' - 'A'))
 #define MCPUID_I       (1L << ('I' - 'A'))
@@ -34,12 +34,11 @@ struct riscv_def_t {
 };
 
 /* RISC-V CPU definitions */
-static const riscv_def_t riscv_defs[] =
-{
+static const riscv_def_t riscv_defs[] = {
     {
         .name = "riscv",
 #if defined(TARGET_RISCV64)
-        // RV64G
+        /* RV64G */
         .init_misa_reg = MCPUID_RV64I | MCPUID_SUPER | MCPUID_USER | MCPUID_I
             | MCPUID_M | MCPUID_A | MCPUID_F | MCPUID_D,
 #else
@@ -49,7 +48,7 @@ static const riscv_def_t riscv_defs[] =
     },
 };
 
-static const riscv_def_t *cpu_riscv_find_by_name (const char *name)
+static const riscv_def_t *cpu_riscv_find_by_name(const char *name)
 {
     int i;
     for (i = 0; i < ARRAY_SIZE(riscv_defs); i++) {
@@ -60,7 +59,7 @@ static const riscv_def_t *cpu_riscv_find_by_name (const char *name)
     return NULL;
 }
 
-void riscv_cpu_list (FILE *f, fprintf_function cpu_fprintf)
+void riscv_cpu_list(FILE *f, fprintf_function cpu_fprintf)
 {
     int i;
     for (i = 0; i < ARRAY_SIZE(riscv_defs); i++) {


### PR DESCRIPTION
Hey Sagar,

I'm mostly finished with my cleanups and it now runs through checkpatch.pl without too much trouble. 
I basically have three types of problems left:

1) ERROR: externs should be avoided in .c files
    #4075: FILE: target-riscv/helper.c:35:
    int validate_priv2(target_ulong priv);
    
    I guess this needs some redesign of the functions and I'm not quite sure how to do it, without breaking too much :)

2) ERROR: braces {} are necessary for all arms of this statement
    #5013: FILE: target-riscv/op_helper.c:98:
    #define RM ({ if (rm == 7) rm = env->csr[CSR_FRM]; \
    
    Checkpatch doesn't like this kind of makro definition and I'm not 100% sure on how to change it.

3) ERROR: if this code is redundant consider removing it
    #3953: FILE: target-riscv/gdbstub.c:101:
    +#if 0
   
    I wasn't sure here if this could be removed. I guess we can postpone this to when we prepare the patches.

Cheers,
    Bastian 

P.S. while doing the cleanup I tested it by booting linux and a gcc warning appeared which the second commit fixes.