### PR TITLE
target-riscv: Optimize mulhsu

### DIFF
--- a/target-riscv/helper.h
+++ b/target-riscv/helper.h
@@ -4,8 +4,9 @@ DEF_HELPER_1(raise_exception_debug, noreturn, env)
 DEF_HELPER_3(raise_exception_mbadaddr, noreturn, env, i32, tl)
 
 /* MULHSU helper */
+#if defined(TARGET_RISCV64)
 DEF_HELPER_FLAGS_3(mulhsu, TCG_CALL_NO_RWG_SE, tl, env, tl, tl)
-
+#endif
 /* Floating Point - fused */
 DEF_HELPER_FLAGS_5(fmadd_s, TCG_CALL_NO_RWG, i64, env, i64, i64, i64, i64)
 DEF_HELPER_FLAGS_5(fmadd_d, TCG_CALL_NO_RWG, i64, env, i64, i64, i64, i64)

--- a/target-riscv/op_helper.c
+++ b/target-riscv/op_helper.c
@@ -629,20 +629,15 @@ target_ulong helper_fclass_d(CPURISCVState *env, uint64_t frs1)
     return frs1;
 }
 
+#if defined(TARGET_RISCV64)
 target_ulong helper_mulhsu(CPURISCVState *env, target_ulong arg1,
                           target_ulong arg2)
 {
-#if defined(TARGET_RISCV64)
     int64_t a = arg1;
     uint64_t b = arg2;
     return (int64_t)((__int128_t)a * b >> 64);
-#else
-    int32_t a = arg1;
-    uint32_t b = arg2;
-    return (int32_t)((int64_t)a * b >> 32);
-#endif
 }
-
+#endif
 /*
  * Handle writes to CSRs and any resulting special behavior
  *


### PR DESCRIPTION
calling a helper is expensive, so lets make at least mulhsu for RV32 use tcg-ops.

Signed-off-by: Bastian Koppelmann <kbastian@mail.uni-paderborn.de>