### PR TITLE
Add SiFive SDK-compatible board

### DIFF
--- a/hw/riscv/Makefile.objs
+++ b/hw/riscv/Makefile.objs
@@ -4,3 +4,4 @@ obj-y += htif/elf_symb.o
 obj-y += htif/htif.o
 obj-y += riscv_board.o
 obj-y += sifive_board.o
+obj-y += sifive_uart.o

--- a/hw/riscv/Makefile.objs
+++ b/hw/riscv/Makefile.objs
@@ -3,3 +3,4 @@ obj-y += riscv_int.o
 obj-y += htif/elf_symb.o
 obj-y += htif/htif.o
 obj-y += riscv_board.o
+obj-y += sifive_board.o

--- a/hw/riscv/sifive_board.c
+++ b/hw/riscv/sifive_board.c
@@ -34,7 +34,6 @@
 #include "qemu/osdep.h"
 #include "hw/hw.h"
 #include "hw/char/serial.h"
-#include "hw/riscv/htif/htif.h"
 #include "hw/riscv/riscv_rtc.h"
 #include "hw/boards.h"
 #include "hw/riscv/cpudevs.h"
@@ -237,12 +236,6 @@ static void riscv_sifive_board_init(MachineState *args)
         stb_p(memory_region_get_ram_ptr(main_mem) + reset_vec[3] + q,
               config_string[q]);
     }
-
-    /* add memory mapped htif registers at location specified in the symbol
-       table of the elf being loaded (thus kernel_filename is passed to the
-       init rather than an address) */
-    htif_mm_init(system_memory, kernel_filename, env->irq[4], main_mem,
-            env, serial_hds[0]);
 
     sifive_uart_create(0x40002000, serial_hds[0]);
 

--- a/hw/riscv/sifive_board.c
+++ b/hw/riscv/sifive_board.c
@@ -45,6 +45,7 @@
 #include "elf.h"
 #include "exec/address-spaces.h"
 #include "hw/sysbus.h"             /* SysBusDevice */
+#include "hw/riscv/sifive_uart.h"
 #include "qemu/host-utils.h"
 #include "sysemu/qtest.h"
 #include "qemu/error-report.h"
@@ -168,8 +169,29 @@ static void riscv_sifive_board_init(MachineState *args)
         "  vendor ucb;\n"
         "  arch spike;\n"
         "};\n"
+        "plic { \n"
+        "  interface \"plic\"; \n"
+        "  ndevs 2; \n"
+        "  priority { mem { 0x60000000 0x60000fff; }; }; \n"
+        "  pending  { mem { 0x60001000 0x6000107f; }; }; \n"
+        "  0 { \n"
+        "    0 { \n"
+        "      m { \n"
+        "        ie  { mem { 0x60002000 0x6000207f; }; }; \n"
+        "        ctl { mem { 0x60200000 0x60200007; }; }; \n"
+        "      }; \n"
+        "      s { \n"
+        "        ie  { mem { 0x60002080 0x600020ff; }; }; \n"
+        "        ctl { mem { 0x60201000 0x60201007; }; }; \n"
+        "      }; \n"
+        "    }; \n"
+        "  }; \n"
+        "}; \n"
         "rtc {\n"
         "  addr 0x" "40000000" ";\n"
+        "};\n"
+        "uart {\n"
+        "  addr 0x40002000;\n"
         "};\n"
         "ram {\n"
         "  0 {\n"
@@ -221,6 +243,8 @@ static void riscv_sifive_board_init(MachineState *args)
        init rather than an address) */
     htif_mm_init(system_memory, kernel_filename, env->irq[4], main_mem,
             env, serial_hds[0]);
+
+    sifive_uart_create(0x40002000, serial_hds[0]);
 
     /* timer device at 0x40000000, as specified in the config string above */
     timer_mm_init(system_memory, 0x40000000, env);

--- a/hw/riscv/sifive_board.c
+++ b/hw/riscv/sifive_board.c
@@ -52,8 +52,8 @@
 #include "qemu/error-report.h"
 #include "sysemu/block-backend.h"
 
-#define TYPE_RISCV_SPIKE_BOARD "spike"
-#define RISCV_SPIKE_BOARD(obj) OBJECT_CHECK(BoardState, (obj), TYPE_RISCV_SPIKE_BOARD)
+#define TYPE_RISCV_SIFIVE_BOARD "riscv"
+#define RISCV_SIFIVE_BOARD(obj) OBJECT_CHECK(BoardState, (obj), TYPE_RISCV_SIFIVE_BOARD)
 
 typedef struct {
     SysBusDevice parent_obj;
@@ -93,7 +93,7 @@ static void main_cpu_reset(void *opaque)
     cpu_reset(CPU(cpu));
 }
 
-static void riscv_spike_board_init(MachineState *args)
+static void riscv_sifive_board_init(MachineState *args)
 {
     ram_addr_t ram_size = args->ram_size;
     const char *cpu_model = args->cpu_model;
@@ -105,7 +105,7 @@ static void riscv_spike_board_init(MachineState *args)
     RISCVCPU *cpu;
     CPURISCVState *env;
     int i;
-    DeviceState *dev = qdev_create(NULL, TYPE_RISCV_SPIKE_BOARD);
+    DeviceState *dev = qdev_create(NULL, TYPE_RISCV_SIFIVE_BOARD);
     object_property_set_bool(OBJECT(dev), true, "realized", NULL);
 
     /* Make sure the first 3 serial ports are associated with a device. */
@@ -139,7 +139,7 @@ static void riscv_spike_board_init(MachineState *args)
     env = &cpu->env;
 
     /* register system main memory (actual RAM) */
-    memory_region_init_ram(main_mem, NULL, "riscv_spike_board.ram", 2147483648L +
+    memory_region_init_ram(main_mem, NULL, "riscv_sifive_board.ram", 2147483648L +
                            ram_size, &error_fatal);
     /* for phys mem size check in page table walk */
     env->memsize = ram_size;
@@ -228,37 +228,36 @@ static void riscv_spike_board_init(MachineState *args)
     /* TODO: VIRTIO */
 }
 
-static int riscv_spike_board_sysbus_device_init(SysBusDevice *sysbusdev)
+static int riscv_sifive_board_sysbus_device_init(SysBusDevice *sysbusdev)
 {
     return 0;
 }
 
-static void riscv_spike_board_class_init(ObjectClass *klass, void *data)
+static void riscv_sifive_board_class_init(ObjectClass *klass, void *data)
 {
     SysBusDeviceClass *k = SYS_BUS_DEVICE_CLASS(klass);
-    k->init = riscv_spike_board_sysbus_device_init;
+    k->init = riscv_sifive_board_sysbus_device_init;
 }
 
-static const TypeInfo riscv_spike_board_device = {
-    .name          = TYPE_RISCV_SPIKE_BOARD,
+static const TypeInfo riscv_sifive_board_device = {
+    .name          = TYPE_RISCV_SIFIVE_BOARD,
     .parent        = TYPE_SYS_BUS_DEVICE,
     .instance_size = sizeof(BoardState),
-    .class_init    = riscv_spike_board_class_init,
+    .class_init    = riscv_sifive_board_class_init,
 };
 
-static void riscv_spike_board_machine_init(MachineClass *mc)
+static void riscv_sifive_board_machine_init(MachineClass *mc)
 {
-    mc->desc = "RISC-V Generic Board (matching 'Spike')";
-    mc->init = riscv_spike_board_init;
+    mc->desc = "RISC-V SiFive Dev Kit Board (Incomplete)";
+    mc->init = riscv_sifive_board_init;
     mc->max_cpus = 1;
-    mc->is_default = 1;
 }
 
-DEFINE_MACHINE("spike", riscv_spike_board_machine_init)
+DEFINE_MACHINE("sifive", riscv_sifive_board_machine_init)
 
-static void riscv_spike_board_register_types(void)
+static void riscv_sifive_board_register_types(void)
 {
-    type_register_static(&riscv_spike_board_device);
+    type_register_static(&riscv_sifive_board_device);
 }
 
-type_init(riscv_spike_board_register_types);
+type_init(riscv_sifive_board_register_types);

--- a/hw/riscv/sifive_board.c
+++ b/hw/riscv/sifive_board.c
@@ -1,14 +1,11 @@
 /*
- * QEMU RISC-V Generic Board Support
+ * QEMU RISC-V SiFive U500 SDK Compatible Board
  *
  * Author: Sagar Karandikar, sagark@eecs.berkeley.edu
  *
  * This provides a RISC-V Board with the following devices:
  *
- * 0) HTIF Test Pass/Fail Reporting (no syscall proxy)
- * 1) HTIF Console
- *
- * These are created by htif_mm_init below.
+ * 0) UART comptible with that expected by the SiFive U500 SDK
  *
  * This board currently uses a hardcoded devicetree that indicates one hart.
  *
@@ -52,7 +49,7 @@
 #include "qemu/error-report.h"
 #include "sysemu/block-backend.h"
 
-#define TYPE_RISCV_SIFIVE_BOARD "riscv"
+#define TYPE_RISCV_SIFIVE_BOARD "sifive_board"
 #define RISCV_SIFIVE_BOARD(obj) OBJECT_CHECK(BoardState, (obj), TYPE_RISCV_SIFIVE_BOARD)
 
 typedef struct {
@@ -265,7 +262,7 @@ static const TypeInfo riscv_sifive_board_device = {
 
 static void riscv_sifive_board_machine_init(MachineClass *mc)
 {
-    mc->desc = "RISC-V SiFive Dev Kit Board (Incomplete)";
+    mc->desc = "RISC-V Board compatible with SiFive U500 SDK (incomplete)";
     mc->init = riscv_sifive_board_init;
     mc->max_cpus = 1;
 }

--- a/hw/riscv/sifive_uart.c
+++ b/hw/riscv/sifive_uart.c
@@ -1,0 +1,186 @@
+/*
+ * QEMU model of the UART on the SiFive U500 SoC (identity unknown).
+ *
+ * Copyright (c) 2016 Stefan O'Rear
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "qemu/osdep.h"
+#include "hw/sysbus.h"
+#include "sysemu/char.h"
+
+/* I have no documentation on the part/IP block, this is reverse engineered
+ * from the driver.  Structually derived from hw/char/xilinx_uartlite.c.
+ */
+
+#define DUART(x)
+
+#define R_DATA          0
+#define R_TXCNT         1
+#define R_RXCNT         2
+#define R_DIV           3
+#define R_MAX           4
+
+#define TYPE_SIFIVE_UART "riscv.sifive-uart"
+#define SIFIVE_UART(obj) \
+    OBJECT_CHECK(SiFiveUART, (obj), TYPE_SIFIVE_UART)
+
+typedef struct SiFiveUART {
+    SysBusDevice parent_obj;
+
+    MemoryRegion mmio;
+    CharDriverState *chr;
+
+    uint8_t rx_fifo[8];
+    unsigned int rx_fifo_len;
+} SiFiveUART;
+
+static void sifive_uart_reset(DeviceState *dev)
+{
+}
+
+static uint64_t
+uart_read(void *opaque, hwaddr addr, unsigned int size)
+{
+    SiFiveUART *s = opaque;
+    unsigned char r;
+    switch (addr >> 2)
+    {
+        case R_DATA:
+            if (s->rx_fifo_len) {
+                r = s->rx_fifo[0];
+                memmove(s->rx_fifo, s->rx_fifo + 1, s->rx_fifo_len - 1);
+                s->rx_fifo_len--;
+                qemu_chr_accept_input(s->chr);
+                return r;
+            }
+            return 0;
+
+        case R_RXCNT:
+            return s->rx_fifo_len;
+
+        default:
+            hw_error("%s: bad read: addr=%x\n", __func__, (int)addr);
+            return 0;
+    }
+    return r;
+}
+
+static void
+uart_write(void *opaque, hwaddr addr,
+           uint64_t val64, unsigned int size)
+{
+    SiFiveUART *s = opaque;
+    uint32_t value = val64;
+    unsigned char ch = value;
+
+    switch (addr >> 2)
+    {
+        case R_DATA:
+            if (s->chr)
+                /* XXX this blocks entire thread. Rewrite to use
+                 * qemu_chr_fe_write and background I/O callbacks */
+                qemu_chr_fe_write_all(s->chr, &ch, 1);
+            break;
+
+        default:
+            hw_error("%s: bad write: addr=%x v=%x\n", __func__, (int)addr, (int)value);
+            break;
+    }
+}
+
+static const MemoryRegionOps uart_ops = {
+    .read = uart_read,
+    .write = uart_write,
+    .endianness = DEVICE_NATIVE_ENDIAN,
+    .valid = {
+        .min_access_size = 4,
+        .max_access_size = 4
+    }
+};
+
+static Property sifive_uart_properties[] = {
+    DEFINE_PROP_CHR("chardev", SiFiveUART, chr),
+    DEFINE_PROP_END_OF_LIST(),
+};
+
+static void uart_rx(void *opaque, const uint8_t *buf, int size)
+{
+    SiFiveUART *s = opaque;
+
+    /* Got a byte.  */
+    if (s->rx_fifo_len >= sizeof(s->rx_fifo)) {
+        printf("WARNING: UART dropped char.\n");
+        return;
+    }
+    s->rx_fifo[s->rx_fifo_len++] = *buf;
+}
+
+static int uart_can_rx(void *opaque)
+{
+    SiFiveUART *s = opaque;
+
+    return s->rx_fifo_len < sizeof(s->rx_fifo);
+}
+
+static void uart_event(void *opaque, int event)
+{
+}
+
+static void sifive_uart_realize(DeviceState *dev, Error **errp)
+{
+    SiFiveUART *s = SIFIVE_UART(dev);
+
+    if (s->chr)
+        qemu_chr_add_handlers(s->chr, uart_can_rx, uart_rx, uart_event, s);
+}
+
+static void sifive_uart_init(Object *obj)
+{
+    SiFiveUART *s = SIFIVE_UART(obj);
+
+    memory_region_init_io(&s->mmio, obj, &uart_ops, s,
+                          "riscv.sifive_uart", R_MAX * 4);
+    sysbus_init_mmio(SYS_BUS_DEVICE(obj), &s->mmio);
+}
+
+static void sifive_uart_class_init(ObjectClass *klass, void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+
+    dc->reset = sifive_uart_reset;
+    dc->realize = sifive_uart_realize;
+    dc->props = sifive_uart_properties;
+}
+
+static const TypeInfo sifive_uart_info = {
+    .name          = TYPE_SIFIVE_UART,
+    .parent        = TYPE_SYS_BUS_DEVICE,
+    .instance_size = sizeof(SiFiveUART),
+    .instance_init = sifive_uart_init,
+    .class_init    = sifive_uart_class_init,
+};
+
+static void sifive_uart_register_types(void)
+{
+    type_register_static(&sifive_uart_info);
+}
+
+type_init(sifive_uart_register_types)

--- a/include/hw/riscv/cpudevs.h
+++ b/include/hw/riscv/cpudevs.h
@@ -5,9 +5,6 @@
 
 /* Definitions for RISCV CPU internal devices.  */
 
-/* riscv_board.c */
-uint64_t identity_translate(void *opaque, uint64_t addr);
-
 /* riscv_int.c */
 void cpu_riscv_irq_init_cpu(CPURISCVState *env);
 

--- a/include/hw/riscv/sifive_uart.h
+++ b/include/hw/riscv/sifive_uart.h
@@ -1,0 +1,33 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 or later, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SIFIVE_UART_H
+#define SIFIVE_UART_H
+
+static inline DeviceState *sifive_uart_create(hwaddr addr,
+                                        CharDriverState *chr)
+{
+    DeviceState *dev;
+    SysBusDevice *s;
+
+    dev = qdev_create(NULL, "riscv.sifive-uart");
+    s = SYS_BUS_DEVICE(dev);
+    qdev_prop_set_chr(dev, "chardev", chr);
+    qdev_init_nofail(dev);
+    sysbus_mmio_map(s, 0, addr);
+
+    return dev;
+}
+
+#endif


### PR DESCRIPTION
This is mostly the same code I sent you on Sep 11, but it's now in a new "sifive" board; the existing board is not modified except to make clear that it's a Spike board.  New board has a UART and removes HTIF.  Also includes directions about how to use it; might be a good idea to sanity-check it.

The SiFive SDK is capable of running on the Spike board as well; you'll be able to tell which you're using because of the flow control problem with the HTIF console (try pasting a small amount of text or using the arrow keys).

Also I don't know what the memory map on the actual hardware is; I'm going entirely off of the device drivers.

Also fixed the README to mention that the docker image is based on F25 (next stable), not F24 (current stable).