### PR TITLE
Fix sigreturn

### DIFF
--- a/linux-user/signal.c
+++ b/linux-user/signal.c
@@ -254,7 +254,7 @@ int do_sigprocmask(int how, const sigset_t *set, sigset_t *oldset)
 }
 
 #if !defined(TARGET_OPENRISC) && !defined(TARGET_UNICORE32) && \
-    !defined(TARGET_X86_64) && !defined(TARGET_RISCV)
+    !defined(TARGET_X86_64)
 /* Just set the guest's signal mask to the specified value; the
  * caller is assumed to have called block_signals() already.
  */
@@ -6044,10 +6044,12 @@ static void restore_ucontext(CPURISCVState* env, struct target_ucontext* uc)
     target_sigset_t target_set;
     int i;
 
+    target_sigemptyset(&target_set);
     for(i = 0; i < TARGET_NSIG_WORDS; i++)
         __get_user(target_set.sig[i], &(uc->uc_sigmask.sig[i]));
 
     target_to_host_sigset_internal(&blocked, &target_set);
+    set_sigmask(&blocked);
 
     restore_sigcontext(env, &uc->uc_mcontext);
 }

--- a/linux-user/signal.c
+++ b/linux-user/signal.c
@@ -6035,7 +6035,7 @@ static void restore_sigcontext(CPURISCVState *env, struct target_sigcontext *sc)
 
     uint32_t fcsr;
     __get_user(fcsr, &sc->fcsr);
-    csr_write_helper(env, CSR_FCSR, fcsr);
+    csr_write_helper(env, fcsr, CSR_FCSR);
 }
 
 static void restore_ucontext(CPURISCVState* env, struct target_ucontext* uc)


### PR DESCRIPTION
With these changes parallel gcc builds now work, as well as some ad-hoc sigaltstack tests.

Test program which demonstrates all of the fixes (except unlock_user_struct, which is only relevant with DEBUG_REMAP)

```
#include <signal.h>
#include <string.h>
#include <stdio.h>
#include <unistd.h>
char altstack[2][65536];

void pstack(char* where) {
	int var;
	char buf[256];
	stack_t ss2;
	sigaltstack(0,&ss2);
	sprintf(buf, "%s, sp=%lx, altsp=%lx, altfl=%x\n", where, (long)&var, (long)ss2.ss_sp, (int)ss2.ss_flags);
	write(2, buf, strlen(buf));
}

void setstack(int which) {
	stack_t ss;
	ss.ss_flags = 0;
	ss.ss_size=sizeof(altstack[which]);
	ss.ss_sp=&altstack[which][0];
	sigaltstack(&ss,0);
}

void usr1hand2(int sig) {
	pstack("enter usr1/2");
	setstack(1);
	pstack("exit usr1/2");
}

void usr1hand(int sig) {
	pstack("enter usr1");
	raise(SIGUSR2);
	pstack("exit usr1");
}

void usr2hand(int sig) {
	pstack("enter usr2");
}


int main() {
	pstack("main program");
	struct sigaction sa;
	memset(&sa,0,sizeof(sa));
	setstack(0);

	/* check restore */
	sa.sa_flags = 0;
	sa.sa_handler = usr1hand2;
	sigaction(SIGUSR1, &sa, 0);
	pstack("after sigaction (check restore)");
	raise(SIGUSR1);
	raise(SIGUSR1);
	pstack("after raise");

	/* check nesting */
	sa.sa_flags = SA_ONSTACK;
	sa.sa_handler = usr1hand;
	sigaction(SIGUSR1, &sa, 0);
	sa.sa_flags = SA_ONSTACK;
	sa.sa_handler = usr2hand;
	sigaction(SIGUSR2, &sa, 0);
	pstack("after sigaction (check nesting)");
	raise(SIGUSR1);
	raise(SIGUSR1);
	pstack("after raise");
	return 0;
}	
```
