### PR TITLE
Fixes for RV64 on ILP32 hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,13 @@ The following packages are used above and beyond what is in a minimal Fedora 24 
 dnf install @buildsys-build git wget texinfo bison flex bc python perl-Thread-Queue vim-common
 ```
 
-Download the SDK (this is tested for rev f3a86d9664d821408318602d7f99e6aaf1e2cb4b):
+Download the SDK; the version given is the most recent which is compatible with QEMU (privilege spec 1.9):
 
 ```
-git clone --recursive https://github.com/sifive/freedom-u-sdk
+git clone https://github.com/sifive/freedom-u-sdk
+cd freedom-u-sdk
+git reset --hard 5d38ed5d
+git submodule update --init --recursive
 ```
 
 Patch to allow the image to boot on emulated hardware that supports floating point, apply this in the `riscv-pk` directory:

--- a/hw/riscv/htif/htif.c
+++ b/hw/riscv/htif/htif.c
@@ -163,7 +163,7 @@ static void htif_handle_tohost_write(HTIFState *htifstate, uint64_t val_written)
             if (payload & 0x1) {
                 /* test result */
                 if (payload >> 1) {
-                    printf("*** FAILED *** (exitcode = %016lx)\n",
+                    printf("*** FAILED *** (exitcode = %016" PRIx64 ")\n",
                            payload >> 1);
                 } else {
                     printf("TEST PASSED\n");
@@ -243,8 +243,8 @@ static void htif_handle_tohost_write(HTIFState *htifstate, uint64_t val_written)
         resp = 0x1; /* write to indicate device name placed */
     } else {
         fprintf(stderr, "HTIF UNKNOWN DEVICE OR COMMAND!\n");
-        fprintf(stderr, "-device: %d\n-cmd: %d\n-what: %02lx\n-payload: \
-                         %016lx\n", device, cmd, payload & 0xFF, payload);
+        fprintf(stderr, "-device: %d\n-cmd: %d\n-what: %02" PRIx64 "\n-payload: \
+                         %016" PRIx64 "\n", device, cmd, payload & 0xFF, payload);
         exit(1);
     }
     while (!htifstate->fromhost_inprogress &&
@@ -277,7 +277,8 @@ static uint64_t htif_mm_read(void *opaque, hwaddr addr, unsigned size)
     } else if (addr == FROMHOST_OFFSET2) {
         return (htifstate->env->mfromhost >> 32) & 0xFFFFFFFF;
     } else {
-        printf("Invalid htif register address %016lx\n", (uint64_t)addr);
+        printf("Invalid htif register address %016" PRIx64 "\n",
+               (uint64_t)addr);
         exit(1);
     }
 }
@@ -318,7 +319,8 @@ static void htif_mm_write(void *opaque, hwaddr addr,
         }
         htifstate->fromhost_inprogress = 0;
     } else {
-        printf("Invalid htif register address %016lx\n", (uint64_t)addr);
+        printf("Invalid htif register address %016" PRIx64 "\n",
+               (uint64_t)addr);
         exit(1);
     }
 }

--- a/hw/riscv/riscv_board.c
+++ b/hw/riscv/riscv_board.c
@@ -139,7 +139,7 @@ static void riscv_spike_board_init(MachineState *args)
     env = &cpu->env;
 
     /* register system main memory (actual RAM) */
-    memory_region_init_ram(main_mem, NULL, "riscv_spike_board.ram", 2147483648L +
+    memory_region_init_ram(main_mem, NULL, "riscv_spike_board.ram", 2147483648ll +
                            ram_size, &error_fatal);
     /* for phys mem size check in page table walk */
     env->memsize = ram_size;
@@ -194,7 +194,7 @@ static void riscv_spike_board_init(MachineState *args)
     /* build config string with supplied memory size */
     uint64_t rsz = ram_size;
     char *ramsize_as_hex_str = malloc(17);
-    sprintf(ramsize_as_hex_str, "%016lx", rsz);
+    sprintf(ramsize_as_hex_str, "%016" PRIx64, rsz);
     char *config_string = malloc(strlen(config_string1) +
                                   strlen(ramsize_as_hex_str) +
                                   strlen(config_string2) + 1);

--- a/hw/riscv/riscv_rtc.c
+++ b/hw/riscv/riscv_rtc.c
@@ -175,7 +175,8 @@ static uint64_t timer_mm_read(void *opaque, hwaddr addr, unsigned size)
         printf("TIMECMP READ NOT IMPL\n");
         exit(1);
     } else {
-        printf("Invalid timer register address %016lx\n", (uint64_t)addr);
+        printf("Invalid timer register address %016" PRIx64 "\n",
+               (uint64_t)addr);
         exit(1);
     }
 }
@@ -201,7 +202,8 @@ static void timer_mm_write(void *opaque, hwaddr addr, uint64_t value,
         write_timecmp(timerstate->env, value << 32 |
                 timerstate->timecmp_lower);
     } else {
-        printf("Invalid timer register address %016lx\n", (uint64_t)addr);
+        printf("Invalid timer register address %016" PRIx64 "\n",
+               (uint64_t)addr);
         exit(1);
     }
 }

--- a/hw/riscv/sifive_board.c
+++ b/hw/riscv/sifive_board.c
@@ -136,7 +136,7 @@ static void riscv_sifive_board_init(MachineState *args)
     env = &cpu->env;
 
     /* register system main memory (actual RAM) */
-    memory_region_init_ram(main_mem, NULL, "riscv_sifive_board.ram", 2147483648L +
+    memory_region_init_ram(main_mem, NULL, "riscv_sifive_board.ram", 2147483648ll +
                            ram_size, &error_fatal);
     /* for phys mem size check in page table walk */
     env->memsize = ram_size;
@@ -212,7 +212,7 @@ static void riscv_sifive_board_init(MachineState *args)
     /* build config string with supplied memory size */
     uint64_t rsz = ram_size;
     char *ramsize_as_hex_str = malloc(17);
-    sprintf(ramsize_as_hex_str, "%016lx", rsz);
+    sprintf(ramsize_as_hex_str, "%016" PRIx64, rsz);
     char *config_string = malloc(strlen(config_string1) +
                                   strlen(ramsize_as_hex_str) +
                                   strlen(config_string2) + 1);

--- a/target-riscv/helper.c
+++ b/target-riscv/helper.c
@@ -84,7 +84,7 @@ static int get_physical_address(CPURISCVState *env, hwaddr *physical,
     }
 
     if (mode == PRV_M) {
-        target_ulong msb_mask = (2UL << (TARGET_LONG_BITS - 1)) - 1;
+        target_ulong msb_mask = (((target_ulong)2) << (TARGET_LONG_BITS - 1)) - 1;
                                         /*0x7FFFFFFFFFFFFFFF; */
         *physical = address & msb_mask;
         *prot = PAGE_READ | PAGE_WRITE | PAGE_EXEC;
@@ -385,7 +385,7 @@ void riscv_cpu_do_interrupt(CPUState *cs)
         /* hacky for now. the MSB (bit 63) indicates interrupt but cs->exception
            index is only 32 bits wide */
         fixed_cause = cs->exception_index & 0x0FFFFFFF;
-        fixed_cause |= (1L << 63);
+        fixed_cause |= ((target_ulong)1) << (TARGET_LONG_BITS - 1);
     } else {
         /* fixup User ECALL -> correct priv ECALL */
         if (cs->exception_index == RISCV_EXCP_U_ECALL) {
@@ -422,7 +422,7 @@ void riscv_cpu_do_interrupt(CPUState *cs)
         (fixed_cause == RISCV_EXCP_STORE_AMO_ACCESS_FAULT);
 
     if (bit & ((target_ulong)1 << (TARGET_LONG_BITS - 1))) {
-        deleg = env->mideleg, bit &= ~(1L << (TARGET_LONG_BITS - 1));
+        deleg = env->mideleg, bit &= ~((target_ulong)1 << (TARGET_LONG_BITS - 1));
     }
 
     if (env->priv <= PRV_S && bit < 64 && ((deleg >> bit) & 1)) {

--- a/target-riscv/helper.c
+++ b/target-riscv/helper.c
@@ -275,7 +275,7 @@ void riscv_cpu_unassigned_access(CPUState *cs, hwaddr addr, bool is_write,
 {
     printf("unassigned address not implemented for riscv\n");
     printf("are you trying to fetch instructions from an MMIO page?\n");
-    printf("unassigned Address: %016lX\n", addr);
+    printf("unassigned Address: %016" PRIx64 "\n", addr);
     exit(1);
 }
 

--- a/target-riscv/init.c
+++ b/target-riscv/init.c
@@ -1,8 +1,8 @@
 #include "qemu/osdep.h"
 #include "cpu.h"
 
-#define MCPUID_RV64I   (2L << (TARGET_LONG_BITS - 2))
-#define MCPUID_RV32I   (1L << (TARGET_LONG_BITS - 2))
+#define MCPUID_RV64I   ((target_ulong)2 << (TARGET_LONG_BITS - 2))
+#define MCPUID_RV32I   ((target_ulong)1 << (TARGET_LONG_BITS - 2))
 #define MCPUID_SUPER   (1L << ('S' - 'A'))
 #define MCPUID_USER    (1L << ('U' - 'A'))
 #define MCPUID_I       (1L << ('I' - 'A'))

--- a/target-riscv/translate.c
+++ b/target-riscv/translate.c
@@ -321,7 +321,7 @@ static void gen_arith(DisasContext *ctx, uint32_t opc, int rd, int rs1,
         tcg_gen_movi_tl(resultopt1, (target_ulong)-1);
         tcg_gen_setcondi_tl(TCG_COND_EQ, cond2, source2, (target_ulong)(~0L));
         tcg_gen_setcondi_tl(TCG_COND_EQ, cond1, source1,
-                            1L << (TARGET_LONG_BITS - 1));
+                            ((target_ulong)1) << (TARGET_LONG_BITS - 1));
         tcg_gen_and_tl(cond1, cond1, cond2); /* cond1 = overflow */
         tcg_gen_setcondi_tl(TCG_COND_EQ, cond2, source2, 0); /* cond2 = div 0 */
         /* if div by zero, set source1 to -1, otherwise don't change */

--- a/target-riscv/translate.c
+++ b/target-riscv/translate.c
@@ -1538,7 +1538,7 @@ void riscv_cpu_dump_state(CPUState *cs, FILE *f, fprintf_function cpu_fprintf,
         if ((i & 3) == 0) {
             cpu_fprintf(f, "FPR%02d:", i);
         }
-        cpu_fprintf(f, " %s %016lx", fpr_regnames[i], env->fpr[i]);
+        cpu_fprintf(f, " %s %016" PRIx64, fpr_regnames[i], env->fpr[i]);
         if ((i & 3) == 3) {
             cpu_fprintf(f, "\n");
         }


### PR DESCRIPTION
This contains @kito-cheng's #45 .

With this patch I was able to build riscv-qemu and sifive-u-sdk in an i686 Debian chroot and then boot Linux with the initramfs.

@shrshore May be of interest to you… note, the emulated RISC-V environment is still 64-bit, so you will use the riscv64-* tools.