### PR TITLE
Remove brk special handling

### DIFF
--- a/linux-user/elfload.c
+++ b/linux-user/elfload.c
@@ -1980,6 +1980,9 @@ static void load_elf_image(const char *image_name, int image_fd,
                 if (vaddr_ef > info->end_data) {
                     info->end_data = vaddr_ef;
                 }
+                if (vaddr_em > info->brk) {
+                    info->brk = vaddr_em;
+                }
             }
         } else if (eppnt->p_type == PT_INTERP && pinterp_name) {
             char *interp_name;
@@ -2014,11 +2017,8 @@ static void load_elf_image(const char *image_name, int image_fd,
     if (info->end_data == 0) {
         info->start_data = info->end_code;
         info->end_data = info->end_code;
+        info->brk = info->end_code;
     }
-
-    /* Heap should be located past both .text and .data */
-    info->brk = (info->end_code > info->end_data ?
-            info->end_code : info->end_data);
 
     if (qemu_log_enabled()) {
         load_symbols(ehdr, image_fd, load_bias);


### PR DESCRIPTION
Reverts arsv/riscv-qemu@6268f398; this should fix the observed segfaults
on statically linked binaries with the new linker script.

I have *not tested this* but it is offered as a fix for riscv/riscv-binutils-gdb#52 .