### PR TITLE
hw/sifive_board: set correct base address for RAM region

### DIFF
--- a/hw/riscv/sifive_board.c
+++ b/hw/riscv/sifive_board.c
@@ -99,6 +99,8 @@ static void riscv_sifive_board_init(MachineState *args)
     const char *initrd_filename = args->initrd_filename;
     MemoryRegion *system_memory = get_system_memory();
     MemoryRegion *main_mem = g_new(MemoryRegion, 1);
+    MemoryRegion *boot_rom = g_new(MemoryRegion, 1);
+    MemoryRegion *dummy_ipi = g_new(MemoryRegion, 1);
     RISCVCPU *cpu;
     CPURISCVState *env;
     int i;
@@ -135,13 +137,25 @@ static void riscv_sifive_board_init(MachineState *args)
     cpu = RISCV_CPU(first_cpu);
     env = &cpu->env;
 
-    /* register system main memory (actual RAM) */
-    memory_region_init_ram(main_mem, NULL, "riscv_sifive_board.ram", 2147483648ll +
+    /* register RAM */
+    memory_region_init_ram(main_mem, NULL, "riscv_sifive_board.ram",
                            ram_size, &error_fatal);
     /* for phys mem size check in page table walk */
     env->memsize = ram_size;
     vmstate_register_ram_global(main_mem);
-    memory_region_add_subregion(system_memory, 0x0, main_mem);
+    memory_region_add_subregion(system_memory, DRAM_BASE, main_mem);
+
+    /* boot rom */
+    memory_region_init_ram(boot_rom, NULL, "riscv_sifive_board.bootrom",
+                           0x10000, &error_fatal);
+    vmstate_register_ram_global(boot_rom);
+    memory_region_set_readonly(boot_rom, true);
+    memory_region_add_subregion(system_memory, 0x0, boot_rom);
+
+    /* allocate dummy ram region for "nop" IPI */
+    memory_region_init_ram(dummy_ipi, NULL, "riscv_sifive_board.dummyipi",
+                           8, &error_fatal);
+    memory_region_add_subregion(system_memory, 0x40001000, dummy_ipi);
 
     if (kernel_filename) {
         loaderparams.ram_size = ram_size;
@@ -204,7 +218,7 @@ static void riscv_sifive_board_init(MachineState *args)
           "    " "0 {\n"
           "      isa " "rv64imafd" ";\n"
           "      timecmp 0x" "40000008" ";\n"
-          "      ipi 0x" "40001000" ";\n"
+          "      ipi 0x" "40001000" ";\n" // this must match dummy ipi region above
           "    };\n"
           "  };\n"
           "};\n";
@@ -224,13 +238,13 @@ static void riscv_sifive_board_init(MachineState *args)
     /* copy in the reset vec and configstring */
     int q;
     for (q = 0; q < sizeof(reset_vec) / sizeof(reset_vec[0]); q++) {
-        stl_p(memory_region_get_ram_ptr(main_mem) + 0x1000 + q * 4,
+        stl_p(memory_region_get_ram_ptr(boot_rom) + 0x1000 + q * 4,
               reset_vec[q]);
     }
 
     int confstrlen = strlen(config_string);
     for (q = 0; q < confstrlen; q++) {
-        stb_p(memory_region_get_ram_ptr(main_mem) + reset_vec[3] + q,
+        stb_p(memory_region_get_ram_ptr(boot_rom) + reset_vec[3] + q,
               config_string[q]);
     }
 


### PR DESCRIPTION
At the moment the qemu sifive board 'riscv_sifive_board.ram'
region overlap devices regions.
E.g. please see 'info mtree' qemu monitor command output:

    (qemu) info mtree
    address-space: memory
      0000000000000000-ffffffffffffffff (prio 0, RW): system
        0000000000000000-0000000087ffffff (prio 0, RW):
    riscv_sifive_board.ram
        0000000040000000-000000004000000f (prio 0, RW): timer
        0000000040002000-000000004000200f (prio 0, RW): riscv.sifive_uart

    address-space: I/O
      0000000000000000-000000000000ffff (prio 0, RW): io

    address-space: cpu-memory
      0000000000000000-ffffffffffffffff (prio 0, RW): system
        0000000000000000-0000000087ffffff (prio 0, RW): riscv_sifive_board.ram
        0000000040000000-000000004000000f (prio 0, RW): timer
        0000000040002000-000000004000200f (prio 0, RW): riscv.sifive_uart

Here is the memory map from chapter of the SiFive E3 Coreplex Series Manual:

    base          top           description
    0x0000_1000   0x0000_ffff   Small ROM Area (60 KiB)
    ...
    0x4800_0000   0x4fff_ffff   On-Coreplex Devices (128 MiB)
    ...
    0x8000_0000   0xffff_ffff   RAM Area (2 KiB)

This patch removes the region overlaping by setting RAM region
base address to 0x80000000 and adding separate memory device
for BootROM ('rom'). Please see the 'info mtree' qemu monitor
command output after applying the patch:

    (qemu) info mtree
    address-space: memory
      0000000000000000-ffffffffffffffff (prio 0, RW): system
        0000000000000000-000000000000ffff (prio 0, R-): rom
        0000000040000000-000000004000000f (prio 0, RW): timer
        0000000040002000-000000004000200f (prio 0, RW): riscv.sifive_uart
        0000000080000000-0000000087ffffff (prio 0, RW): ram

    address-space: I/O
      0000000000000000-000000000000ffff (prio 0, RW): io

    address-space: cpu-memory
      0000000000000000-ffffffffffffffff (prio 0, RW): system
        0000000000000000-000000000000ffff (prio 0, R-): rom
        0000000040000000-000000004000000f (prio 0, RW): timer
        0000000040002000-000000004000200f (prio 0, RW): riscv.sifive_uart
        0000000080000000-0000000087ffffff (prio 0, RW): ram

Signed-off-by: Antony Pavlov <antonynpavlov@gmail.com>