### PR TITLE
Update UART model to match shipped FE310

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ and then hit `ctrl-a x`. Otherwise, the root filesystem will likely be corrupted
 Support for other HTIF-based devices has been removed from [riscv-linux]; as a
 result, QEMU no longer supports them either.
 
-<!--### Method 1b \(Full-System Simulation compatible with the SiFive U500 SDK \):
+### Method 1b \(Full-System Simulation compatible with the SiFive U500 SDK \):
 
 (this is very incomplete, and is based mostly on software reverse engineering)
 
@@ -116,7 +116,7 @@ Download the SDK; the version given is the most recent which is compatible with 
 ```
 git clone https://github.com/sifive/freedom-u-sdk
 cd freedom-u-sdk
-git reset --hard 5d38ed5d
+git reset --hard b38f7c98
 git submodule update --init --recursive
 ```
 
@@ -131,7 +131,7 @@ index f885b30..8babada 100644
  #  - CXXFLAGS : flags for C++ compiler (eg. -Wall,-g,-O3)
 
  CC            := @CC@
--CFLAGS        := @CFLAGS@ $(CFLAGS) -DBBL_PAYLOAD=\"$(bbl_payload)\" -msoft-float
+-CFLAGS        := @CFLAGS@ $(CFLAGS) -DBBL_PAYLOAD=\"$(bbl_payload)\" -mno-float
 +CFLAGS        := @CFLAGS@ $(CFLAGS) -DBBL_PAYLOAD=\"$(bbl_payload)\"
  COMPILE       := $(CC) -MMD -MP $(CFLAGS) \
                   $(sprojs_include)
@@ -145,7 +145,6 @@ make -j4
 ```
 
 (This step took roughly 20 minutes and created 9.3G of files.)
--->
 
 #### Step 3: Run QEMU
 


### PR DESCRIPTION
Fixes #54.  Still not implemented: TX flow control, interrupts,
configuration registers; but this is enough for bbl.