### PR TITLE
Fix building on recent glibc

### DIFF
--- a/qga/commands-posix.c
+++ b/qga/commands-posix.c
@@ -41,6 +41,10 @@ extern char **environ;
 #include <sys/socket.h>
 #include <net/if.h>
 
+#if __GLIBC__ > 1
+#include <sys/sysmacros.h>
+#endif
+
 #ifdef FIFREEZE
 #define CONFIG_FSFREEZE
 #endif


### PR DESCRIPTION
Building against recent glibc versions results in the following error:
```
qga/commands-posix.c:656:13: error: In the GNU C Library, "major" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "major", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "major", you should undefine it after including <sys/types.h>. [-Werror]
```
This patch resolves the error by conditionally including `<sys/sysmacros.h>` if a recent glibc version is present.