### PR TITLE
[spike_v1.10] add device tree htif node

### DIFF
--- a/hw/riscv/spike_v1_10.c
+++ b/hw/riscv/spike_v1_10.c
@@ -100,6 +100,9 @@ static void create_fdt(SpikeState *s, uint64_t mem_base, uint64_t mem_size)
     qemu_fdt_setprop_cell(fdt, "/", "#size-cells", 0x2);
     qemu_fdt_setprop_cell(fdt, "/", "#address-cells", 0x2);
 
+    qemu_fdt_add_subnode(fdt, "/htif");
+    qemu_fdt_setprop_string(fdt, "/htif", "compatible", "ucb,htif0");
+
     qemu_fdt_add_subnode(fdt, "/soc");
     qemu_fdt_setprop(fdt, "/soc", "ranges", NULL, 0);
     qemu_fdt_setprop_string(fdt, "/soc", "compatible", "ucbbar,spike-bare-soc");


### PR DESCRIPTION
@sagark this is essential to merge due to a breaking change made in bbl in the last couple of weeks. 

Can you please merge this ASAP. It is a low risk change. It just adds an HTIF node to device-tree for the spike-v1.10 board so that we can run top of tree. It's a backwards compatible change. I'ts in the plic branch but i've cherry-picked it so we can get this fix in for the distro builders. It's required to run the spike kernel image from top of tree freedom-u-sdk.

```
$ qemu-system-riscv64 -nographic -machine spike_v1.10,dumpdtb=spike.dts
$ fdtdump spike.dts 

**** fdtdump is a low-level debugging tool, not meant for general use.
**** If you want to decompile a dtb, you probably want
****     dtc -I dtb -O dts <filename>

/dts-v1/;
// magic:		0xd00dfeed
// totalsize:		0x10000 (65536)
// off_dt_struct:	0x40
// off_dt_strings:	0x340
// off_mem_rsvmap:	0x30
// version:		17
// last_comp_version:	16
// boot_cpuid_phys:	0x0
// size_dt_strings:	0xd0
// size_dt_struct:	0x300

/ {
    #address-cells = <0x00000002>;
    #size-cells = <0x00000002>;
    compatible = "ucbbar,spike-bare-dev";
    model = "ucbbar,spike-bare,qemu";
    cpus {
        #address-cells = <0x00000001>;
        #size-cells = <0x00000000>;
        timebase-frequency = <0x00989680>;
        cpu@0 {
            device_type = "cpu";
            reg = <0x00000000>;
            status = "okay";
            compatible = "riscv";
            riscv,isa = "rv64imafdc";
            mmu-type = "riscv,sv48";
            clock-frequency = <0x3b9aca00>;
            interrupt-controller {
                #interrupt-cells = <0x00000001>;
                interrupt-controller;
                compatible = "riscv,cpu-intc";
                linux,phandle = <0x00000001>;
                phandle = <0x00000001>;
            };
        };
    };
    memory@80000000 {
        device_type = "memory";
        reg = <0x00000000 0x80000000 0x00000000 0x08000000>;
    };
    soc {
        #address-cells = <0x00000002>;
        #size-cells = <0x00000002>;
        compatible = "ucbbar,spike-bare-soc";
        ranges;
        clint@2000000 {
            interrupts-extended = <0x00000001 0x00000003 0x00000001 0x00000007>;
            reg = <0x00000000 0x02000000 0x00000000 0x000c0000>;
            compatible = "riscv,clint0";
        };
    };
    htif {
        compatible = "ucb,htif0";
    };
};
```

BTW does anyone know the default user and password for the builtroot image?

```
$ qemu-system-riscv64 -nographic -machine spike_v1.10 -kernel bbl-1.10-u 

                SIFIVE, INC.

         5555555555555555555555555
        5555                   5555
       5555                     5555
      5555                       5555
     5555       5555555555555555555555
    5555       555555555555555555555555
   5555                             5555
  5555                               5555
 5555                                 5555
5555555555555555555555555555          55555
 55555           555555555           55555
   55555           55555           55555
     55555           5           55555
       55555                   55555
         55555               55555
           55555           55555
             55555       55555
               55555   55555
                 555555555
                   55555
                     5

           SiFive RISC-V Coreplex
[    0.000000] OF: fdt: Ignoring memory range 0x80000000 - 0x80200000
[    0.000000] Linux version 4.14.0-rc7-00028-g160fa8470d0f (riscv@excalibur) (gcc version 7.2.0 (GCC)) #2 SMP Sat Dec 2 14:37:40 CET 2017
[    0.000000] bootconsole [early0] enabled
[    0.000000] Initial ramdisk at: 0xffffffe00001e200 (5672960 bytes)
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000080200000-0x0000000087ffffff]
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000080200000-0x0000000087ffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000080200000-0x0000000087ffffff]
[    0.000000] elf_hwcap is 0x112d
[    0.000000] percpu: Embedded 14 pages/cpu @ffffffe007c2e000 s28376 r0 d28968 u57344
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 31815
[    0.000000] Kernel command line: earlyprintk 
[    0.000000] PID hash table entries: 512 (order: 0, 4096 bytes)
[    0.000000] Dentry cache hash table entries: 16384 (order: 5, 131072 bytes)
[    0.000000] Inode-cache hash table entries: 8192 (order: 4, 65536 bytes)
[    0.000000] Sorting __ex_table...
[    0.000000] Memory: 116604K/129024K available (2826K kernel code, 239K rwdata, 751K rodata, 5695K init, 774K bss, 12420K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] Hierarchical RCU implementation.
[    0.000000] 	RCU event tracing is enabled.
[    0.000000] 	RCU restricting CPUs from NR_CPUS=8 to nr_cpu_ids=1.
[    0.000000] RCU: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=1
[    0.000000] NR_IRQS: 0, nr_irqs: 0, preallocated irqs: 0
[    0.000000] riscv,cpu_intc,0: 64 local interrupts mapped
[    0.000000] clocksource: riscv_clocksource: mask: 0xffffffffffffffff max_cycles: 0x24e6a1710, max_idle_ns: 440795202120 ns
[    0.000000] console [hvc0] enabled
[    0.000000] console [hvc0] enabled
[    0.000000] bootconsole [early0] disabled
[    0.000000] bootconsole [early0] disabled
[    0.000000] Calibrating delay loop (skipped), value calculated using timer frequency.. 20.00 BogoMIPS (lpj=100000)
[    0.000000] pid_max: default: 32768 minimum: 301
[    0.000000] Mount-cache hash table entries: 512 (order: 0, 4096 bytes)
[    0.000000] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes)
[    0.020000] Hierarchical SRCU implementation.
[    0.020000] smp: Bringing up secondary CPUs ...
[    0.020000] smp: Brought up 1 node, 1 CPU
[    0.050000] devtmpfs: initialized
[    0.060000] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.060000] futex hash table entries: 256 (order: 2, 16384 bytes)
[    0.070000] random: get_random_u32 called from bucket_table_alloc+0xe6/0x276 with crng_init=0
[    0.070000] NET: Registered protocol family 16
[    0.100000] vgaarb: loaded
[    0.100000] SCSI subsystem initialized
[    0.100000] usbcore: registered new interface driver usbfs
[    0.100000] usbcore: registered new interface driver hub
[    0.100000] usbcore: registered new device driver usb
[    0.100000] pps_core: LinuxPPS API ver. 1 registered
[    0.110000] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
[    0.110000] PTP clock support registered
[    0.110000] clocksource: Switched to clocksource riscv_clocksource
[    0.120000] NET: Registered protocol family 2
[    0.120000] TCP established hash table entries: 1024 (order: 1, 8192 bytes)
[    0.120000] TCP bind hash table entries: 1024 (order: 2, 16384 bytes)
[    0.120000] TCP: Hash tables configured (established 1024 bind 1024)
[    0.120000] UDP hash table entries: 256 (order: 1, 8192 bytes)
[    0.120000] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes)
[    0.120000] NET: Registered protocol family 1
[    0.440000] Unpacking initramfs...
[    0.800000] workingset: timestamp_bits=62 max_order=15 bucket_order=0
[    0.850000] random: fast init done
[    0.860000] io scheduler noop registered
[    0.860000] io scheduler cfq registered (default)
[    0.860000] io scheduler mq-deadline registered
[    0.860000] io scheduler kyber registered
[    1.050000] e1000e: Intel(R) PRO/1000 Network Driver - 3.2.6-k
[    1.050000] e1000e: Copyright(c) 1999 - 2015 Intel Corporation.
[    1.050000] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
[    1.050000] ehci-pci: EHCI PCI platform driver
[    1.050000] usbcore: registered new interface driver usb-storage
[    1.050000] IR NEC protocol handler initialized
[    1.060000] IR RC5(x/sz) protocol handler initialized
[    1.060000] IR RC6 protocol handler initialized
[    1.060000] IR JVC protocol handler initialized
[    1.060000] IR Sony protocol handler initialized
[    1.060000] IR SANYO protocol handler initialized
[    1.060000] IR Sharp protocol handler initialized
[    1.060000] IR MCE Keyboard/mouse protocol handler initialized
[    1.060000] IR XMP protocol handler initialized
[    1.060000] usbcore: registered new interface driver usbhid
[    1.060000] usbhid: USB HID core driver
[    1.070000] NET: Registered protocol family 17
[    1.090000] Freeing unused kernel memory: 5692K
[    1.090000] This architecture does not have kernel memory protection.
Starting logging: OK
Starting mdev...
modprobe: can't change directory to '/lib/modules': No such file or directory
Initializing random number generator... done.
Starting network...
Waiting for interface eth0 to appear............... timeout!
run-parts: /etc/network/if-pre-up.d/wait_iface: exit status 1
Starting dropbear sshd: OK

Welcome to Buildroot
buildroot login: root
Password: 
Login incorrect
buildroot login: root
Password: 
Login incorrect
buildroot login: 
Login timed out after 60 seconds

Welcome to Buildroot
buildroot login: 
```