### PR TITLE
Minimal WFI implementation

### DIFF
--- a/target-riscv/helper.h
+++ b/target-riscv/helper.h
@@ -72,6 +72,7 @@ DEF_HELPER_4(csrrc, tl, env, tl, tl, tl)
 #ifndef CONFIG_USER_ONLY
 DEF_HELPER_2(sret, tl, env, tl)
 DEF_HELPER_2(mret, tl, env, tl)
+DEF_HELPER_1(wfi, void, env)
 DEF_HELPER_1(tlb_flush, void, env)
 DEF_HELPER_1(fence_i, void, env)
 #endif

--- a/target-riscv/op_helper.c
+++ b/target-riscv/op_helper.c
@@ -683,6 +683,15 @@ target_ulong helper_mret(CPURISCVState *env, target_ulong cpu_pc_deb)
 }
 
 
+void helper_wfi(CPURISCVState *env)
+{
+    CPUState *cs = CPU(riscv_env_get_cpu(env));
+
+    cs->halted = 1;
+    cs->exception_index = EXCP_HLT;
+    cpu_loop_exit(cs);
+}
+
 void helper_fence_i(CPURISCVState *env)
 {
     RISCVCPU *cpu = riscv_env_get_cpu(env);

--- a/target-riscv/translate.c
+++ b/target-riscv/translate.c
@@ -1392,7 +1392,8 @@ static void gen_system(DisasContext *ctx, uint32_t opc,
             exit(1);
             break;
         case 0x105: /* WFI */
-            /* nop for now, as in spike */
+            tcg_gen_movi_tl(cpu_pc, ctx->next_pc);
+            gen_helper_wfi(cpu_env);
             break;
         case 0x104: /* SFENCE.VM */
             gen_helper_tlb_flush(cpu_env);


### PR DESCRIPTION
- Don't chew 100% CPU when linux is calling WFI. QEMU no longer
  chews 100% CPU when idle. PLIC support will come later as
  Linux kernel is not using the PLIC yet.
- This patch differs by avoiding changes to existing interrupt
  logic. cpu_riscv_hw_interrupts_pending needs to be reviewed
  in context of the PLIC changes when merged.

This patch is the minimal change derived from Stephan O'Rear's change:

- https://github.com/riscv/riscv-qemu/pull/59/commits/c4bc523317f623819a28584cf51f42c627e74063

This patch has been cherry-picked from this branch

- https://github.com/michaeljclark/riscv-qemu/tree/plic

Please consider merging either the individual `minimal-wfi` and `htif-device-tree` pull requests or just merge the `plic` branch which has all of these changes rolled up including the travis fixes, minimal WFI implementation, and the HTIF device tree patches.

All branches have been tested against the test binaries.