### PR TITLE
Change RISC-V virt board to use 16550 UART instead of HTIF

### DIFF
--- a/hw/riscv/virt.c
+++ b/hw/riscv/virt.c
@@ -44,7 +44,7 @@
 #include "exec/address-spaces.h"
 #include "elf.h"
 
-//#define RISCV_SERIAL_CONSOLE
+#define RISCV_SERIAL_CONSOLE
 
 static const struct MemmapEntry {
     hwaddr base;


### PR DESCRIPTION
The SBI/HTIF polled mode console driver has some issues such
as dropping characters when output is copy and pasted as well
as key code mismatches for up/down arrows for shell history.

This patch enables UART 16550 console for the virt board.
The console is exposed in device-tree and automatically
detected by linux kernel when the following kernel config
options are enabled.

  CONFIG_SERIAL_8250=y
  CONFIG_SERIAL_8250_CONSOLE=y
  CONFIG_SERIAL_OF_PLATFORM=y

Note: the root image inittab should refer to /dev/console
or /dev/ttyS0 instead of /dev/hvc0