### PR TITLE
Add support for passing kernel command line using -append

### DIFF
--- a/hw/riscv/sifive_u500.c
+++ b/hw/riscv/sifive_u500.c
@@ -83,7 +83,7 @@ static uint64_t load_kernel(const char *kernel_filename)
 }
 
 static void create_fdt(SiFiveU500State *s, const struct MemmapEntry *memmap,
-    uint64_t mem_size)
+    uint64_t mem_size, const char *cmdline)
 {
     void *fdt;
     int cpu;
@@ -195,6 +195,10 @@ static void create_fdt(SiFiveU500State *s, const struct MemmapEntry *memmap,
         0x0, memmap[SIFIVE_U500_UART0].size);
     qemu_fdt_setprop_cells(fdt, nodename, "interrupt-parent", plic_phandle);
     qemu_fdt_setprop_cells(fdt, nodename, "interrupts", 1);
+
+    qemu_fdt_add_subnode(fdt, "/chosen");
+    qemu_fdt_setprop_string(fdt, "/chosen", "stdout-path", nodename);
+    qemu_fdt_setprop_string(fdt, "/chosen", "bootargs", cmdline);
     g_free(nodename);
 }
 
@@ -227,7 +231,7 @@ static void riscv_sifive_u500_init(MachineState *machine)
         main_mem);
 
     /* create device tree */
-    create_fdt(s, memmap, machine->ram_size);
+    create_fdt(s, memmap, machine->ram_size, machine->kernel_cmdline);
 
     /* boot rom */
     memory_region_init_ram(boot_rom, NULL, "riscv.sifive.u500.bootrom",

--- a/hw/riscv/spike_v1_10.c
+++ b/hw/riscv/spike_v1_10.c
@@ -77,7 +77,7 @@ static uint64_t load_kernel(const char *kernel_filename)
 }
 
 static void create_fdt(SpikeState *s, const struct MemmapEntry *memmap,
-    uint64_t mem_size)
+    uint64_t mem_size, const char *cmdline)
 {
     void *fdt;
     int cpu;
@@ -149,7 +149,10 @@ static void create_fdt(SpikeState *s, const struct MemmapEntry *memmap,
         g_free(intc);
         g_free(nodename);
     }
-}
+
+    qemu_fdt_add_subnode(fdt, "/chosen");
+    qemu_fdt_setprop_string(fdt, "/chosen", "bootargs", cmdline);
+ }
 
 static void riscv_spike_board_init(MachineState *machine)
 {
@@ -182,7 +185,7 @@ static void riscv_spike_board_init(MachineState *machine)
         main_mem);
 
     /* create device tree */
-    create_fdt(s, memmap, machine->ram_size);
+    create_fdt(s, memmap, machine->ram_size, machine->kernel_cmdline);
 
     /* boot rom */
     memory_region_init_ram(boot_rom, NULL, "riscv_spike_board.bootrom",

--- a/hw/riscv/virt.c
+++ b/hw/riscv/virt.c
@@ -79,7 +79,7 @@ static uint64_t load_kernel(const char *kernel_filename)
 }
 
 static void create_fdt(RISCVVirtState *s, const struct MemmapEntry *memmap,
-    uint64_t mem_size)
+    uint64_t mem_size, const char *cmdline)
 {
     void *fdt;
     int cpu;
@@ -215,8 +215,13 @@ static void create_fdt(RISCVVirtState *s, const struct MemmapEntry *memmap,
 
     qemu_fdt_add_subnode(fdt, "/chosen");
     qemu_fdt_setprop_string(fdt, "/chosen", "stdout-path", nodename);
+    qemu_fdt_setprop_string(fdt, "/chosen", "bootargs", cmdline);
     g_free(nodename);
+#else
+    qemu_fdt_add_subnode(fdt, "/chosen");
+    qemu_fdt_setprop_string(fdt, "/chosen", "bootargs", cmdline);
 #endif
+
 }
 
 static void riscv_virt_board_init(MachineState *machine)
@@ -248,7 +253,7 @@ static void riscv_virt_board_init(MachineState *machine)
         main_mem);
 
     /* create device tree */
-    create_fdt(s, memmap, machine->ram_size);
+    create_fdt(s, memmap, machine->ram_size, machine->kernel_cmdline);
 
     /* boot rom */
     memory_region_init_ram(boot_rom, NULL, "riscv_virt_board.bootrom",


### PR DESCRIPTION
This patch leverages the linux kernel device-tree command line processing code https://github.com/riscv/riscv-linux/blob/50c4c4e268a2d7a3e58ebb698ac74da0de40ae36/drivers/of/fdt.c#L1095-L1098

With this patch, the user can pass -append "root=/dev/vda ro console=ttyS0" to select root device and console device, instead of hardcoding in CONFIG_CMDLINE e.g.

```
sudo qemu-system-riscv64 -nographic -machine vir \
 -kernel bbl -append "root=/dev/vda console=ttyS0 ro" \
 -drive file=root.bin,format=raw,id=hd0 \
 -device virtio-blk-device,drive=hd0 \
 -netdev type=tap,script=./ifup,downscript=./ifdown,id=net0 \
 -device virtio-net-device,netdev=net0 
```