### PR TITLE
RISC-V has quiet fp eq compare.

### DIFF
--- a/target-riscv/fpu_helper.c
+++ b/target-riscv/fpu_helper.c
@@ -248,7 +248,7 @@ target_ulong helper_flt_s(CPURISCVState *env, uint64_t frs1, uint64_t frs2)
 target_ulong helper_feq_s(CPURISCVState *env, uint64_t frs1, uint64_t frs2)
 {
     require_fp;
-    frs1 = float32_eq(frs1, frs2, &env->fp_status);
+    frs1 = float32_eq_quiet(frs1, frs2, &env->fp_status);
     set_fp_exceptions();
     return frs1;
 }
@@ -471,7 +471,7 @@ target_ulong helper_flt_d(CPURISCVState *env, uint64_t frs1, uint64_t frs2)
 target_ulong helper_feq_d(CPURISCVState *env, uint64_t frs1, uint64_t frs2)
 {
     require_fp;
-    frs1 = float64_eq(frs1, frs2, &env->fp_status);
+    frs1 = float64_eq_quiet(frs1, frs2, &env->fp_status);
     set_fp_exceptions();
     return frs1;
 }


### PR DESCRIPTION
This fixes one more gcc testsuite failure for a rv64gc/lp64d target.  The testcase is gcc.dg/torture/pr68264.c compiled at -O0.  There is no change to g++ and gfortran testsuite results.

