### PR TITLE
(WIP) Another attempt at setting tb_flags

### DIFF
--- a/target/riscv/cpu_bits.h
+++ b/target/riscv/cpu_bits.h
@@ -312,6 +312,17 @@
 #define SIP_STIP            MIP_STIP
 #define SIP_SEIP            MIP_SEIP
 
+#define MISA_RV64I          ((target_ulong)2 << (TARGET_LONG_BITS - 2))
+#define MISA_RV32I          ((target_ulong)1 << (TARGET_LONG_BITS - 2))
+#define MISA_I              (1 << ('I' - 'A'))
+#define MISA_M              (1 << ('M' - 'A'))
+#define MISA_A              (1 << ('A' - 'A'))
+#define MISA_F              (1 << ('F' - 'A'))
+#define MISA_D              (1 << ('D' - 'A'))
+#define MISA_C              (1 << ('C' - 'A'))
+#define MISA_S              (1 << ('S' - 'A'))
+#define MISA_U              (1 << ('U' - 'A'))
+
 #define PRV_U 0
 #define PRV_S 1
 #define PRV_H 2

--- a/target/riscv/helper.c
+++ b/target/riscv/helper.c
@@ -139,6 +139,9 @@ static int get_physical_address(CPURISCVState *env, hwaddr *physical,
 
     int levels, ptidxbits, ptesize, vm, sum;
     int mxr = get_field(env->mstatus, MSTATUS_MXR);
+    /* TODO(sorear): This logic is broken.  PUM and MXR need to be encoded
+       in the mmu_idx so that translations with different rules do not
+       cross-contaminate. */
 
     if (env->priv_ver >= PRIV_VERSION_1_10_0) {
         base = get_field(env->satp, SATP_PPN) << PGSHIFT;

--- a/target/riscv/op_helper.c
+++ b/target/riscv/op_helper.c
@@ -154,6 +154,7 @@ inline void csr_write_helper(CPURISCVState *env, target_ulong val_to_write,
         dirty |= (mstatus & MSTATUS_XS) == MSTATUS_XS;
         mstatus = set_field(mstatus, MSTATUS_SD, dirty);
         env->mstatus = mstatus;
+        cpu_riscv_set_tb_flags(env);
         break;
     }
     case CSR_MIP: {
@@ -329,6 +330,7 @@ inline void csr_write_helper(CPURISCVState *env, target_ulong val_to_write,
         mask &= env->misa_mask;
 
         env->misa = (val_to_write & mask) | (env->misa & ~mask);
+        cpu_riscv_set_tb_flags(env);
         break;
     }
     case CSR_PMPCFG0:
@@ -609,6 +611,7 @@ void riscv_set_mode(CPURISCVState *env, target_ulong newpriv)
     }
     helper_tlb_flush(env);
     env->priv = newpriv;
+    cpu_riscv_set_tb_flags(env);
 }
 
 target_ulong helper_sret(CPURISCVState *env, target_ulong cpu_pc_deb)


### PR DESCRIPTION
I've blindly applied the patch, but I think we need to refactor things a
bit so we no longer look at env->misa and instead look at env->tb_flags.
I'm not sure if removing env->misa is the correct thing to do, or if we
should be making sure it stays in sync with tb_flags.

I doubt this compiles.

This originally came from sorear
<https://github.com/riscv/riscv-qemu/commit/a038a2874a3eba27650c164f4622e47a3fe95199.patch>
and may have missed some diff.