### PR TITLE
cleanup and locking improvement for local interrupts

### DIFF
--- a/configure
+++ b/configure
@@ -6718,10 +6718,12 @@ case "$target_name" in
   riscv32)
     TARGET_BASE_ARCH=riscv
     TARGET_ABI_DIR=riscv
+    mttcg=yes
   ;;
   riscv64)
     TARGET_BASE_ARCH=riscv
     TARGET_ABI_DIR=riscv
+    mttcg=yes
   ;;
   sh4|sh4eb)
     TARGET_ARCH=sh4

--- a/hw/riscv/sifive_clint.c
+++ b/hw/riscv/sifive_clint.c
@@ -53,7 +53,7 @@ static void sifive_clint_irq_request(void *opaque, int irq, int level)
     if (level) {
         cpu_interrupt(cs, CPU_INTERRUPT_HARD);
     } else {
-        if (!env->mip && !env->mfromhost) {
+        if (!env->mip) {
             /* no interrupts pending, no host interrupt for HTIF, reset */
             cpu_reset_interrupt(cs, CPU_INTERRUPT_HARD);
         }

--- a/hw/riscv/spike_v1_09.c
+++ b/hw/riscv/spike_v1_09.c
@@ -160,9 +160,7 @@ static void riscv_spike_board_init(MachineState *machine)
     /* add memory mapped htif registers at location specified in the symbol
        table of the elf being loaded (thus kernel_filename is passed to the
        init rather than an address) */
-    htif_mm_init(system_memory,
-        s->soc.harts[0].env.irq[4], boot_rom,
-        &s->soc.harts[0].env, serial_hds[0]);
+    htif_mm_init(system_memory, boot_rom, &s->soc.harts[0].env, serial_hds[0]);
 
     /* Core Local Interruptor (timer and IPI) */
     sifive_clint_create(0x40000000, 0x2000, smp_cpus, 0x1000, 0x8, 0x0);

--- a/hw/riscv/spike_v1_10.c
+++ b/hw/riscv/spike_v1_10.c
@@ -234,9 +234,7 @@ static void riscv_spike_board_init(MachineState *machine)
     /* add memory mapped htif registers at location specified in the symbol
        table of the elf being loaded (thus kernel_filename is passed to the
        init rather than an address) */
-    htif_mm_init(system_memory,
-        s->soc.harts[0].env.irq[4], boot_rom,
-        &s->soc.harts[0].env, serial_hds[0]);
+    htif_mm_init(system_memory, boot_rom, &s->soc.harts[0].env, serial_hds[0]);
 
     /* Core Local Interruptor (timer and IPI) */
     sifive_clint_create(0x2000000, 0x10000, smp_cpus,

--- a/include/hw/riscv/riscv_htif.h
+++ b/include/hw/riscv/riscv_htif.h
@@ -40,7 +40,6 @@ typedef struct HTIFState {
     hwaddr fromhost_offset;
     uint64_t tohost_size;
     uint64_t fromhost_size;
-    qemu_irq irq; /* host interrupt line */
     MemoryRegion mmio;
     MemoryRegion *address_space;
     MemoryRegion *main_mem;
@@ -59,8 +58,7 @@ void htif_symbol_callback(const char *st_name, int st_info, uint64_t st_value,
     uint64_t st_size);
 
 /* legacy pre qom */
-HTIFState *htif_mm_init(MemoryRegion *address_space,
-    qemu_irq irq, MemoryRegion *main_mem,
+HTIFState *htif_mm_init(MemoryRegion *address_space, MemoryRegion *main_mem,
     CPURISCVState *env, Chardev *chr);
 
 #endif

--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -173,7 +173,8 @@ static void riscv_cpu_dump_state(CPUState *cs, FILE *f,
 #ifndef CONFIG_USER_ONLY
     cpu_fprintf(f, " %s " TARGET_FMT_lx "\n", "MSTATUS ",
                 env->mstatus);
-    cpu_fprintf(f, " %s " TARGET_FMT_lx "\n", "MIP     ", env->mip);
+    target_ulong mip = atomic_read(&env->mip);
+    cpu_fprintf(f, " %s " TARGET_FMT_lx "\n", "MIP     ", mip);
     cpu_fprintf(f, " %s " TARGET_FMT_lx "\n", "MIE     ", env->mie);
 #endif
 

--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -206,7 +206,13 @@ static void riscv_cpu_synchronize_from_tb(CPUState *cs, TranslationBlock *tb)
 
 static bool riscv_cpu_has_work(CPUState *cs)
 {
-    return cs->interrupt_request & CPU_INTERRUPT_HARD;
+    RISCVCPU *cpu = RISCV_CPU(cs);
+    CPURISCVState *env = &cpu->env;
+    /*
+     * Definition of the WFI instruction requires it to ignore the privilege
+     * mode and delegation registers, but respect individual enables
+     */
+    return (atomic_read(&env->mip) & env->mie) != 0;
 }
 
 void restore_state_to_opc(CPURISCVState *env, TranslationBlock *tb,

--- a/target/riscv/cpu.h
+++ b/target/riscv/cpu.h
@@ -13,6 +13,8 @@
 #define TARGET_VIRT_ADDR_SPACE_BITS 32
 #endif
 
+#define TCG_GUEST_DEFAULT_MO 0
+
 #define ELF_MACHINE EM_RISCV
 #define CPUArchState struct CPURISCVState
 

--- a/target/riscv/cpu_bits.h
+++ b/target/riscv/cpu_bits.h
@@ -347,7 +347,6 @@
 #define IRQ_H_EXT       10 /* until: priv-1.9.1 */
 #define IRQ_M_EXT       11 /* until: priv-1.9.1 */
 #define IRQ_X_COP       12 /* non-standard */
-#define IRQ_X_HOST      13 /* non-standard */
 
 /* Default addresses */
 #define DEFAULT_RSTVEC     0x00001000

--- a/target/riscv/helper.c
+++ b/target/riscv/helper.c
@@ -56,17 +56,7 @@ static int riscv_cpu_hw_interrupts_pending(CPURISCVState *env)
                           -s_enabled;
 
     if (enabled_interrupts) {
-        target_ulong counted = ctz64(enabled_interrupts); /* since non-zero */
-        if (counted == IRQ_X_HOST) {
-            /* we're handing it to the cpu now, so get rid of the qemu irq */
-            qemu_irq_lower(HTIF_IRQ);
-        } else if (counted == IRQ_M_TIMER) {
-            /* we're handing it to the cpu now, so get rid of the qemu irq */
-            qemu_irq_lower(MTIP_IRQ);
-        } else if (counted == IRQ_S_TIMER || counted == IRQ_H_TIMER) {
-            /* don't lower irq here */
-        }
-        return counted;
+        return ctz64(enabled_interrupts); /* since non-zero */
     } else {
         return EXCP_NONE; /* indicates no pending interrupt */
     }

--- a/target/riscv/helper.c
+++ b/target/riscv/helper.c
@@ -43,7 +43,7 @@ int riscv_cpu_mmu_index(CPURISCVState *env, bool ifetch)
  */
 static int riscv_cpu_hw_interrupts_pending(CPURISCVState *env)
 {
-    target_ulong pending_interrupts = env->mip & env->mie;
+    target_ulong pending_interrupts = atomic_read(&env->mip) & env->mie;
 
     target_ulong mie = get_field(env->mstatus, MSTATUS_MIE);
     target_ulong m_enabled = env->priv < PRV_M || (env->priv == PRV_M && mie);


### PR DESCRIPTION
I expect these to be squashed as part of the v6 so the commit messages are targeted to reviewers.  DJ Delorie and myself have given the first commit here of about 6-12 hours of load testing under mttcg; the remaining cleanups are not as well tested, but do boot (virt, spike_v1.9, spike_v1.10).