### PR TITLE
RISC-V - Make updates to PTE accessed and dirty bits atomic

### DIFF
--- a/target/riscv/cpu.h
+++ b/target/riscv/cpu.h
@@ -93,7 +93,7 @@ struct CPURISCVState {
      * operating on it.  CPU_INTERRUPT_HARD should be in effect iff this is
      * non-zero.  Use riscv_cpu_set_local_interrupt.
      */
-    target_ulong mip;
+    uint32_t mip;        /* allow atomic_read for >= 32-bit hosts */
     target_ulong mie;
     target_ulong mideleg;
 

--- a/target/riscv/helper.c
+++ b/target/riscv/helper.c
@@ -217,6 +217,10 @@ restart:
                     } else {
                         pte = updated_pte;
                     }
+                } else {
+                    /* misconfigured PTE in ROM (AD bits are not preset) or
+                     * PTE is in IO space and can't be updated atomically */
+                    return TRANSLATE_FAIL;
                 }
             }
 


### PR DESCRIPTION
The RISC-V Privileged Specification requires that updates
to PTE accessed and dirty bits are atomic. There is a small
race window in the current code between reading the PTE and
updating it. The only reasonable way to make updates atomic
is to use atomic_cmpxchg. To use platform atomics, we need
to translate the guest physical address to a host address.

In the rare case that the atomic_cmpxchg of the PTE fails,
it means the PTE is stale, and we must restart the walk. The
PTE may longer be valid, the permissions may have changed
or the PTE may even point to another physical page. The
simplist approach to handling a conflict is to re-walk
the page tables for the current translation. This is safe
and fast as the likelihood the PTE is stale is rare.

Maliciously crafted supervisor code could attempt to limit
forward progress by hammering the PTE with updates, but it
is likely the page table walker will eventually win the race.
Frequent atomic update failures may exhibit as a pathological
side-effect of a specially crafted supervisor page-walker
denial of service attack. In the uncontended common case,
translation overhead is the same as stl_phys/stq_phys.

This code uses the QEMU address space translation API to
lookup the memory region in the same manner as ldl_phys/
ldq_phys but elides operations if the PTEs are in IO space
or non-writable RAM. This seems to be a reasonable behaviour
for the typical case where PTEs are in RAM, and the atypical
case where PTEs are in ROM or an IO device, where it is
not possible for the updates to occur or be atomic.