### PR TITLE
softfloat: fix crash on int conversion of SNaN

### DIFF
--- a/fpu/softfloat.c
+++ b/fpu/softfloat.c
@@ -1342,6 +1342,8 @@ static int64_t round_to_int_and_pack(FloatParts in, int rmode,
     switch (p.cls) {
     case float_class_snan:
     case float_class_qnan:
+    case float_class_dnan:
+    case float_class_msnan:
         return max;
     case float_class_inf:
         return p.sign ? min : max;
@@ -1430,6 +1432,8 @@ static uint64_t round_to_uint_and_pack(FloatParts in, int rmode, uint64_t max,
     switch (p.cls) {
     case float_class_snan:
     case float_class_qnan:
+    case float_class_dnan:
+    case float_class_msnan:
         s->float_exception_flags = orig_flags | float_flag_invalid;
         return max;
     case float_class_inf:


### PR DESCRIPTION
@sorear Merging softfloat: fix crash on int conversion of SNaN into qemu-all

(last merge went into qemu-next which is now a legacy branch)