### PR TITLE
RISC-V: Fix isa string logic bug, use popcount to count bits

### DIFF
--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -391,7 +391,7 @@ static const TypeInfo riscv_cpu_type_info = {
 char *riscv_isa_string(RISCVCPU *cpu)
 {
     int i;
-    size_t maxlen = 5 + ctz32(cpu->env.misa);
+    size_t maxlen = 5 + __builtin_popcountll(cpu->env.misa);
     char *isa_string = g_new0(char, maxlen);
     snprintf(isa_string, maxlen, "rv%d", TARGET_LONG_BITS);
     for (i = 0; i < sizeof(riscv_exts); i++) {


### PR DESCRIPTION
Fix memory size calculation logic bug in riscv_isa_string. 

```
==17441== Invalid write of size 1
==17441==    at 0x26517F: riscv_isa_string (cpu.c:399)
==17441==    by 0x25C14D: create_fdt (spike.c:125)
==17441==    by 0x25C14D: spike_v1_10_0_board_init (spike.c:199)
==17441==    by 0x2CCE0A: machine_run_board_init (machine.c:807)
==17441==    by 0x1BFF28: main (vl.c:4597)
==17441==  Address 0x3055c425 is 0 bytes after a block of size 5 alloc'd
==17441==    at 0x4C2FB55: calloc (in
/usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17441==    by 0x70C8770: g_malloc0 (in
/lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==17441==    by 0x26511E: riscv_isa_string (cpu.c:395)
==17441==    by 0x25C14D: create_fdt (spike.c:125)
==17441==    by 0x25C14D: spike_v1_10_0_board_init (spike.c:199)
==17441==    by 0x2CCE0A: machine_run_board_init (machine.c:807)
==17441==    by 0x1BFF28: main (vl.c:4597)
```