### PR TITLE
fix bug of pmpcfg_csr_read

### DIFF
--- a/target/riscv/pmp.c
+++ b/target/riscv/pmp.c
@@ -337,7 +337,7 @@ target_ulong pmpcfg_csr_read(CPURISCVState *env, uint32_t reg_index)
 
     for (i = 0; i < sizeof(target_ulong); i++) {
         val = pmp_read_cfg(env, (reg_index * sizeof(target_ulong)) + i);
-        cfg_val |= (val << (i * 8));
+        cfg_val |= ((target_ulong)val << (i * 8));
     }
 
     PMP_DEBUG("hart " TARGET_FMT_ld ": reg%d, val: 0x" TARGET_FMT_lx,


### PR DESCRIPTION
related code:
```c
target_ulong cfg_val = 0;
uint8_t val = 0;
cfg_val |= (val << (i * 8));
```
C language automatic type promotion to int. The length of the int under RV64 may be small with target_ulong, and the upper 32 bits can't be read.