### PR TITLE
fix counter-enable checks in ctr()

### DIFF
--- a/target/riscv/csr.c
+++ b/target/riscv/csr.c
@@ -60,8 +60,14 @@ static int fs(CPURISCVState *env, int csrno)
 static int ctr(CPURISCVState *env, int csrno)
 {
 #if !defined(CONFIG_USER_ONLY)
-    target_ulong ctr_en = env->priv == PRV_U ? env->scounteren :
-                          env->priv == PRV_S ? env->mcounteren : -1U;
+    target_ulong ctr_en = -1;
+
+    if (env->priv < PRV_M) {
+        ctr_en &= env->mcounteren;
+    }
+    if (env->priv < PRV_S) {
+        ctr_en &= env->scounteren;
+    }
     if (!(ctr_en & (1 << (csrno & 31)))) {
         return -1;
     }


### PR DESCRIPTION
The current code ignores mcounteren in U-mode.  It should check both mcounteren and scounteren.

Section 3.1.17: "When the CY, TM, IR, or HPMn bit in the mcounteren register is clear, attempts to read the cycle, time, instret, or hpmcountern register while executing in S-mode or U-mode will cause an illegal instruction exception."